### PR TITLE
fix: provide raw HTTP response in errors that supports body related m…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-workspace-root-check=true

--- a/src/responseUtils.ts
+++ b/src/responseUtils.ts
@@ -1,3 +1,3 @@
-export function getJson<T>(response: Response) {
-  return response.clone().json() as Promise<T>
+export function copyResponseJson(response: Response) {
+  return response.clone().json()
 }

--- a/src/responseUtils.ts
+++ b/src/responseUtils.ts
@@ -1,0 +1,3 @@
+export function getJson<T>(response: Response) {
+  return response.clone().json() as Promise<T>
+}

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -14,7 +14,7 @@ import {
   VisitorsError429,
   VisitorsResponse,
 } from './types'
-import { getJson } from './responseUtils'
+import { copyResponseJson } from './responseUtils'
 
 export class FingerprintJsServerApiClient {
   public readonly region: Region
@@ -81,7 +81,7 @@ export class FingerprintJsServerApiClient {
       headers,
     })
       .then(async (response) => {
-        const jsonResponse = await getJson<EventError | EventResponse>(response)
+        const jsonResponse = await copyResponseJson(response)
 
         if (response.status !== 200) {
           throw { ...jsonResponse, response, status: response.status } as EventError
@@ -145,7 +145,7 @@ export class FingerprintJsServerApiClient {
           return
         }
 
-        const jsonResponse = await getJson<DeleteVisitorError>(response)
+        const jsonResponse = await copyResponseJson(response)
 
         throw { ...(jsonResponse as DeleteVisitorError), response, status: response.status } as DeleteVisitorError
       })
@@ -208,7 +208,7 @@ export class FingerprintJsServerApiClient {
       headers,
     })
       .then(async (response) => {
-        const jsonResponse = await getJson<VisitorsResponse | VisitorsError429 | VisitorsError>(response)
+        const jsonResponse = await copyResponseJson(response)
 
         if (response.status === 200) {
           return jsonResponse as VisitorsResponse

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -14,6 +14,7 @@ import {
   VisitorsError429,
   VisitorsResponse,
 } from './types'
+import { getJson } from './responseUtils'
 
 export class FingerprintJsServerApiClient {
   public readonly region: Region
@@ -80,7 +81,8 @@ export class FingerprintJsServerApiClient {
       headers,
     })
       .then(async (response) => {
-        const jsonResponse = await response.json()
+        const jsonResponse = await getJson<EventError | EventResponse>(response)
+
         if (response.status !== 200) {
           throw { ...jsonResponse, response, status: response.status } as EventError
         }
@@ -143,7 +145,7 @@ export class FingerprintJsServerApiClient {
           return
         }
 
-        const jsonResponse = await response.json()
+        const jsonResponse = await getJson<DeleteVisitorError>(response)
 
         throw { ...(jsonResponse as DeleteVisitorError), response, status: response.status } as DeleteVisitorError
       })
@@ -206,7 +208,8 @@ export class FingerprintJsServerApiClient {
       headers,
     })
       .then(async (response) => {
-        const jsonResponse = await response.json()
+        const jsonResponse = await getJson<VisitorsResponse | VisitorsError429 | VisitorsError>(response)
+
         if (response.status === 200) {
           return jsonResponse as VisitorsResponse
         }

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -1,4 +1,4 @@
-import { FingerprintJsServerApiClient, Region } from '../../src'
+import { EventError, FingerprintJsServerApiClient, isEventError, Region } from '../../src'
 
 describe('ServerApiClient', () => {
   it('should support passing custom fetch implementation', async () => {
@@ -13,5 +13,40 @@ describe('ServerApiClient', () => {
     await client.getVisitorHistory('visitorId')
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors should return response that supports body related methods', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 403,
+          error: {
+            code: 'FeatureNotEnabled',
+            message: 'feature not enabled',
+          },
+        } as Omit<EventError, 'response'>),
+        { status: 403 }
+      )
+    )
+
+    const client = new FingerprintJsServerApiClient({
+      fetch: mockFetch as any,
+      apiKey: 'test',
+      region: Region.Global,
+    })
+
+    try {
+      await client.getEvent('test')
+    } catch (e) {
+      if (isEventError(e)) {
+        expect(e.response.status).toBe(403)
+
+        await expect(e.response.json()).resolves.not.toThrow()
+
+        return
+      }
+    }
+
+    throw new Error('Expected EventError to be thrown')
   })
 })

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -1,11 +1,11 @@
-import { EventError, FingerprintJsServerApiClient, isEventError, Region } from '../../src'
+import { FingerprintJsServerApiClient, isEventError, Region } from '../../src'
 
 describe('ServerApiClient', () => {
   it('should support passing custom fetch implementation', async () => {
     const mockFetch = jest.fn().mockResolvedValue(new Response(JSON.stringify({})))
 
     const client = new FingerprintJsServerApiClient({
-      fetch: mockFetch as any,
+      fetch: mockFetch,
       apiKey: 'test',
       region: Region.Global,
     })
@@ -19,18 +19,17 @@ describe('ServerApiClient', () => {
     const mockFetch = jest.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
-          status: 403,
           error: {
             code: 'FeatureNotEnabled',
             message: 'feature not enabled',
           },
-        } as Omit<EventError, 'response'>),
+        }),
         { status: 403 }
       )
     )
 
     const client = new FingerprintJsServerApiClient({
-      fetch: mockFetch as any,
+      fetch: mockFetch,
       apiKey: 'test',
       region: Region.Global,
     })


### PR DESCRIPTION
…ethods, such as `response.json()`