### PR TITLE
feat: allow enum parameters to be specified as their string literal equivalents

### DIFF
--- a/.changeset/silent-weeks-hope.md
+++ b/.changeset/silent-weeks-hope.md
@@ -1,0 +1,5 @@
+---
+'@fingerprintjs/fingerprintjs-pro-server-api': minor
+---
+
+allow enum parameters to be specified as their string literal equivalents

--- a/src/sealedResults.ts
+++ b/src/sealedResults.ts
@@ -13,7 +13,7 @@ export enum DecryptionAlgorithm {
 
 export interface DecryptionKey {
   key: Buffer
-  algorithm: DecryptionAlgorithm
+  algorithm: DecryptionAlgorithm | `${DecryptionAlgorithm}`
 }
 
 const SEALED_HEADER = Buffer.from([0x9e, 0x85, 0xdc, 0xed])

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -37,9 +37,13 @@ export class FingerprintJsServerApiClient implements FingerprintApi {
       throw Error('Api key is not set')
     }
 
-    this.region = options.region ?? Region.Global
+    // These type assertions are safe because the Options type allows the
+    // region or authentication mode to be specified as a string or an enum value.
+    // The resulting JS from using the enum value or the string is identical.
+    this.region = (options.region as Region) ?? Region.Global
+    this.authenticationMode = (options.authenticationMode as AuthenticationMode) ?? AuthenticationMode.AuthHeader // Default auth mode is AuthHeader
+
     this.apiKey = options.apiKey
-    this.authenticationMode = options.authenticationMode ?? AuthenticationMode.AuthHeader // Default auth mode is AuthHeader
     this.fetch = options.fetch ?? fetch
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,12 @@ export interface Options {
   /**
    * Region of the FingerprintJS service server
    */
-  region?: Region
+  region?: Region | `${Region}`
   /**
    * Authentication mode
    * Optional, default value is AuthHeader
    */
-  authenticationMode?: AuthenticationMode
+  authenticationMode?: AuthenticationMode | `${AuthenticationMode}`
 
   /**
    * Optional fetch implementation

--- a/tests/unit-tests/sealedResults.spec.ts
+++ b/tests/unit-tests/sealedResults.spec.ts
@@ -38,6 +38,23 @@ describe('Unseal event response', () => {
     expect(result).toMatchSnapshot()
   })
 
+  it('unseals sealed data using aes256gcm, passed as a string parameter', async () => {
+    const result = await unsealEventsResponse(sealedData, [
+      {
+        key: invalidKey,
+        algorithm: 'aes-256-gcm',
+      },
+      {
+        key: validKey,
+        algorithm: 'aes-256-gcm',
+      },
+    ])
+
+    // This test just checks that the types provide the expected behavior
+    // so a simple assertion to use the result variable is all that is required
+    expect(result).toBeTruthy()
+  })
+
   it('throws error if header is not correct', async () => {
     const invalidData = Buffer.from(
       'xzXc7SXO+mqeAGrvBMgObi/S0fXTpP3zupk8qFqsO/1zdtWCD169iLA3VkkZh9ICHpZ0oWRzqG0M9/TnCeKFohgBLqDp6O0zEfXOv6i5q++aucItznQdLwrKLP+O0blfb4dWVI8/aSbd4ELAZuJJxj9bCoVZ1vk+ShbUXCRZTD30OIEAr3eiG9aw00y1UZIqMgX6CkFlU9L9OnKLsNsyomPIaRHTmgVTI5kNhrnVNyNsnzt9rY7fUD52DQxJILVPrUJ1Q+qW7VyNslzGYBPG0DyYlKbRAomKJDQIkdj/Uwa6bhSTq4XYNVvbk5AJ/dGwvsVdOnkMT2Ipd67KwbKfw5bqQj/cw6bj8Cp2FD4Dy4Ud4daBpPRsCyxBM2jOjVz1B/lAyrOp8BweXOXYugwdPyEn38MBZ5oL4D38jIwR/QiVnMHpERh93jtgwh9Abza6i4/zZaDAbPhtZLXSM5ztdctv8bAb63CppLU541Kf4OaLO3QLvfLRXK2n8bwEwzVAqQ22dyzt6/vPiRbZ5akh8JB6QFXG0QJF9DejsIspKF3JvOKjG2edmC9o+GfL3hwDBiihYXCGY9lElZICAdt+7rZm5UxMx7STrVKy81xcvfaIp1BwGh/HyMsJnkE8IczzRFpLlHGYuNDxdLoBjiifrmHvOCUDcV8UvhSV+UAZtAVejdNGo5G/bz0NF21HUO4pVRPu6RqZIs/aX4hlm6iO/0Ru00ct8pfadUIgRcephTuFC2fHyZxNBC6NApRtLSNLfzYTTo/uSjgcu6rLWiNo5G7yfrM45RXjalFEFzk75Z/fu9lCJJa5uLFgDNKlU+IaFjArfXJCll3apbZp4/LNKiU35ZlB7ZmjDTrji1wLep8iRVVEGht/DW00MTok7Zn7Fv+MlxgWmbZB3BuezwTmXb/fNw==',


### PR DESCRIPTION
Expand the types for `DecryptionAlgorithm` and `Options` (used to create the `FingerprintJsServerApiClient`) to allow the enum parameters to also be specified as their string literal equivalents. This allows TypeScript users of the SDK to use the string literal equivalents without having to be aware of the enums.

To achieve this, use ["Template Literal Types"](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) to expand the values for string-valued enums to a union type without having to duplicate the string constants.

This approach results in no differences to the JS generated by TypeScript compilation, and as a result, this change just results in a backwards-compatible change to the TypeScript types.

Also:
- Add unit tests to ensure that using the string literals does not result in compilation errors.
- Add a unit test to test usage of the API key as a query parameter