### PR TITLE
Drop visitorId check and refactor functional tests

### DIFF
--- a/tests/functional-tests/smokeTests.mjs
+++ b/tests/functional-tests/smokeTests.mjs
@@ -1,117 +1,92 @@
-import { FingerprintJsServerApiClient, Region, RequestError } from '@fingerprintjs/fingerprintjs-pro-server-api'
+import { FingerprintJsServerApiClient, Region, RequestError, TooManyRequestsError } from '@fingerprintjs/fingerprintjs-pro-server-api'
 import { config } from 'dotenv'
 config()
 
-const apiKey = process.env.API_KEY
-const envRegion = process.env.REGION
-
-if (!apiKey) {
-  console.error('API key not defined')
-  process.exit(1)
-}
-
-let region = Region.Global
-if (envRegion === 'eu') {
-  region = Region.EU
-} else if (envRegion === 'ap') {
-  region = Region.AP
-}
-
+const REGION_MAP = { eu: Region.EU, ap: Region.AP, us: Region.Global }
+const region = REGION_MAP[(process.env.REGION ?? 'us').toLowerCase()] ?? Region.Global
 const end = Date.now()
 const start = end - 90 * 24 * 60 * 60 * 1000
 
-const client = new FingerprintJsServerApiClient({ region, apiKey })
-let visitorId, requestId
-
-// test search events
-try {
-  const searchEventsResponse = await client.searchEvents({ limit: 2, start, end })
-  if (searchEventsResponse.events.length === 0) {
-    console.log('FingerprintJsServerApiClient.searchEvents: is empty')
-    process.exit(1)
-  }
-  const firstEvent = searchEventsResponse.events[0]
-  visitorId = firstEvent.products.identification.data.visitorId
-  requestId = firstEvent.products.identification.data.requestId
-
-  console.log(JSON.stringify(searchEventsResponse, null, 2))
-  const searchEventsResponseSecondPage = await client.searchEvents({
-    limit: 2,
-    start,
-    end,
-    pagination_key: firstEvent.pagination_key,
-  })
-  if (searchEventsResponseSecondPage.events.length === 0) {
-    console.log('Second page of FingerprintJsServerApiClient.searchEvents: is empty')
-    process.exit(1)
-  }
-} catch (error) {
-  if (error instanceof RequestError) {
-    console.log(`error ${error.statusCode}: `, error.message)
-    // You can also access the raw response
-    console.log(error.response.statusText)
-  } else {
-    console.log('unknown error: ', error)
-  }
-  process.exit(1)
-}
-
-// Test getEvent
-try {
-  const event = await client.getEvent(requestId)
-  console.log(JSON.stringify(event, null, 2))
-} catch (error) {
-  if (error instanceof RequestError) {
-    console.log(`error ${error.statusCode}: `, error.message)
-    // You can also access the raw response
-    console.log(error.response.statusText)
-  } else {
-    console.log('unknown error: ', error)
-  }
-  process.exit(1)
-}
-
-// Test getVisits
-try {
-  const visitorHistory = await client.getVisits(visitorId, { limit: 10 })
-  console.log(JSON.stringify(visitorHistory, null, 2))
-} catch (error) {
-  if (error instanceof RequestError) {
-    console.log(error.statusCode, error.message)
-    if (error instanceof TooManyRequestsError) {
-      retryLater(error.retryAfter) // Needs to be implemented on your side
+async function main() {
+  try {
+    if (!process.env['API_KEY']) {
+      console.error('Missing required API_KEY env variable!')
+      process.exitCode = 1
+      return
     }
-  } else {
-    console.error('unknown error: ', error)
+
+    const client = new FingerprintJsServerApiClient({ region, apiKey: process.env.API_KEY })
+
+    console.log('Retrieving recent 2 events...')
+    const recent = await client.searchEvents({ limit: 2, start, end })
+    if (recent.events.length === 0) {
+      console.warn('searchEvents returned no recent events')
+      process.exitCode = 1
+      return
+    }
+
+    const [firstEvent] = recent.events
+    const { visitorId, requestId } = firstEvent.products.identification.data
+    if (firstEvent.pagination_key) {
+      console.log('Retrieving next page...')
+      const recentPage2 = await client.searchEvents({
+        limit: 2,
+        start,
+        end,
+        pagination_key: firstEvent.pagination_key,
+      })
+      if (recentPage2.events.length === 0) {
+        console.warn('searchEvents page 2 returned no events')
+        process.exitCode = 1
+        return
+      }
+    }
+
+    console.log('Retrieving event detail by requestId...')
+    await client.getEvent(requestId)
+    console.log('Retrieving visitor detail by visitorId...')
+    await client.getVisits(visitorId, { limit: 10 })
+
+    console.log('Retrieving old 2 events...')
+    const old = await client.searchEvents({ limit: 2, start, end, reverse: true })
+    if (old.events.length === 0) {
+      console.warn('searchEvents returned no old events')
+      process.exitCode = 1
+      return
+    }
+
+    const [oldestEvent] = old.events
+    const { visitorId: oldVisitorId, requestId: oldRequestId } = oldestEvent.products.identification.data
+
+    if (requestId === oldRequestId) {
+      console.error('Oldest event requestId is identical to the newest one')
+      process.exitCode = 1
+      return
+    }
+
+    console.log('Retrieving oldest event detail by requestId...')
+    await client.getEvent(oldRequestId)
+    console.log('Retrieving oldest visitor detail by visitorId...')
+    await client.getVisits(oldVisitorId)
+
+    console.log('All checks passed')
+  } catch (error) {
+    process.exitCode = 1
+    if (error instanceof TooManyRequestsError) {
+      console.error(`[TooManyRequestsError]: Rate limited. Retry after: ${error.retryAfter}s`)
+      return
+    }
+
+    if (error instanceof RequestError) {
+      console.error(`[RequestError] ${error.statusCode}: ${error.message}`)
+      if (error.response) {
+        console.error(`[RequestError] ${error.response.statusText}`)
+      }
+      return
+    }
+
+    throw error
   }
-  process.exit(1)
 }
 
-// Check that old events are still match expected format
-try {
-  const searchEventsResponseOld = await client.searchEvents({ limit: 2, start, end, reverse: true })
-  if (searchEventsResponseOld.events.length === 0) {
-    console.log('FingerprintJsServerApiClient.searchEvents: is empty for old events')
-    process.exit(1)
-  }
-  const oldEventIdentificationData = searchEventsResponseOld.events[0].products.identification.data
-  const visitorIdOld = oldEventIdentificationData.visitorId
-  const requestIdOld = oldEventIdentificationData.requestId
-
-  if (visitorId === visitorIdOld || requestId === requestIdOld) {
-    console.log('Old events are identical to new')
-    process.exit(1)
-  }
-  await client.getEvent(requestIdOld)
-  await client.getVisits(visitorIdOld)
-  console.log('Old events are good')
-} catch (error) {
-  if (error instanceof RequestError) {
-    console.log(`error ${error.statusCode}: `, error.message)
-    // You can also access the raw response
-    console.log(error.response.statusText)
-  } else {
-    console.log('unknown error: ', error)
-  }
-  process.exit(1)
-}
+await main()


### PR DESCRIPTION
Made the smoke test script simpler and more CI friendly. We no longer compare `visitorId` between recent and oldest events (that was causing false negatives). Tests are wrapped in `main()`, errors are handled in single place, and logs are easier to read

> ⚠️  Removed JSON response logs

## ✏️  What Changed?

- Removed the `visitorId` comparison. Still kept `requestId` check for uniqueness.
- Centralized error handling. Also used `process.exitCode` instead of `process.exit`.
- Region is normalized via `REGION_MAP`.
- Paginate only when `pagination_key` is present.
- Removed some JSON response logs.