### PR TITLE
INTER-1921: Add sdk package name to support e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       sdk: node
       sdkVersion: ${{ needs.read-version.outputs.version }}
+      sdkPackageName: '@fingerprintjs/fingerprintjs-pro-server-api'
       appId: ${{ vars.RUNNER_APP_ID }}
       commitSha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:


### PR DESCRIPTION
Adds SDK package name to support e2e tests for `api-v3` branch changes.