### PR TITLE
feat: include examples in generated type JSDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "husky": "^9.0.11",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.2",
-    "openapi-typescript": "^7.4.2",
+    "openapi-typescript": "^7.13.0",
     "rimraf": "^5.0.5",
     "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^15.2.2
         version: 15.2.2
       openapi-typescript:
-        specifier: ^7.4.2
-        version: 7.4.2(typescript@5.4.2)
+        specifier: ^7.13.0
+        version: 7.13.0(typescript@5.4.2)
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -132,6 +132,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.24.1':
     resolution: {integrity: sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==}
     engines: {node: '>=6.9.0'}
@@ -196,6 +200,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.23.5':
@@ -621,12 +629,12 @@ packages:
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
 
-  '@redocly/config@0.16.0':
-    resolution: {integrity: sha512-t9jnODbUcuANRSl/K4L9nb12V+U5acIHnVSl26NWrtSdDZVtoqUXk2yGFPZzohYf62cCfEQUT8ouJ3bhPfpnJg==}
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
 
-  '@redocly/openapi-core@1.25.11':
-    resolution: {integrity: sha512-bH+a8izQz4fnKROKoX3bEU8sQ9rjvEIZOqU6qTmxlhOJ0NsKa5e+LmU18SV0oFeg5YhWQhhEDihXkvKJ1wMMNQ==}
-    engines: {node: '>=14.19.0', npm: '>=7.0.0'}
+  '@redocly/openapi-core@1.34.15':
+    resolution: {integrity: sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
   '@rollup/plugin-json@6.1.0':
     resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
@@ -920,8 +928,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.1:
-    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
   ajv@6.12.6:
@@ -1034,6 +1042,9 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1242,6 +1253,15 @@ packages:
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -1627,8 +1647,8 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  https-proxy-agent@7.0.5:
-    resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
   human-id@1.0.2:
@@ -1674,8 +1694,8 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  index-to-position@0.1.2:
-    resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
   inflight@1.0.6:
@@ -1947,6 +1967,10 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -2030,9 +2054,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -2150,8 +2171,8 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.3:
@@ -2187,20 +2208,14 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2231,8 +2246,8 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  openapi-typescript@7.4.2:
-    resolution: {integrity: sha512-SvhmSTItcEAdDUcz+wzrcg6OENpMRkHqqY2hZB01FT+NOfgLcZ1B1ML6vcQrnipONHtG9AQELiKHgGTjpNGjiQ==}
+  openapi-typescript@7.13.0:
+    resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
     hasBin: true
     peerDependencies:
       typescript: ^5.x
@@ -2303,8 +2318,8 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
-  parse-json@8.1.0:
-    resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
   parse-passwd@1.0.0:
@@ -2670,6 +2685,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -2681,10 +2700,6 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
-
-  supports-color@9.4.0:
-    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
-    engines: {node: '>=12'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -2726,9 +2741,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
@@ -2780,8 +2792,8 @@ packages:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
 
-  type-fest@4.26.1:
-    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
   typedoc@0.27.9:
@@ -2838,12 +2850,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -2943,6 +2949,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.24.1': {}
 
   '@babel/core@7.24.1':
@@ -2958,7 +2970,7 @@ snapshots:
       '@babel/traverse': 7.24.1
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3021,6 +3033,8 @@ snapshots:
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -3138,7 +3152,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.1
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3420,7 +3434,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -3473,7 +3487,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3720,23 +3734,20 @@ snapshots:
       require-from-string: 2.0.2
       uri-js-replace: 1.0.1
 
-  '@redocly/config@0.16.0': {}
+  '@redocly/config@0.22.0': {}
 
-  '@redocly/openapi-core@1.25.11(supports-color@9.4.0)':
+  '@redocly/openapi-core@1.34.15(supports-color@10.2.2)':
     dependencies:
       '@redocly/ajv': 8.11.2
-      '@redocly/config': 0.16.0
+      '@redocly/config': 0.22.0
       colorette: 1.4.0
-      https-proxy-agent: 7.0.5(supports-color@9.4.0)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.1.0
-      lodash.isequal: 4.5.0
-      minimatch: 5.1.6
-      node-fetch: 2.7.0
+      js-yaml: 4.1.1
+      minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   '@rollup/plugin-json@6.1.0(rollup@4.34.9)':
@@ -3921,7 +3932,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.19.1(eslint@8.56.0)(typescript@5.4.2)
       '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.19.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -3939,7 +3950,7 @@ snapshots:
       '@typescript-eslint/types': 6.19.1
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.19.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       eslint: 8.56.0
     optionalDependencies:
       typescript: 5.4.2
@@ -3955,7 +3966,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.4.2)
       '@typescript-eslint/utils': 6.19.1(eslint@8.56.0)(typescript@5.4.2)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@5.4.2)
     optionalDependencies:
@@ -3969,7 +3980,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.19.1
       '@typescript-eslint/visitor-keys': 6.19.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -4012,11 +4023,7 @@ snapshots:
 
   acorn@8.11.3: {}
 
-  agent-base@7.1.1(supports-color@9.4.0):
-    dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
-    transitivePeerDependencies:
-      - supports-color
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -4149,6 +4156,10 @@ snapshots:
       concat-map: 0.0.1
 
   brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4374,11 +4385,15 @@ snapshots:
 
   dargs@8.1.0: {}
 
-  debug@4.3.4(supports-color@9.4.0):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
+
+  debug@4.4.3(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
     optionalDependencies:
-      supports-color: 9.4.0
+      supports-color: 10.2.2
 
   dedent@0.7.0: {}
 
@@ -4480,7 +4495,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -4779,10 +4794,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  https-proxy-agent@7.0.5(supports-color@9.4.0):
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
-      agent-base: 7.1.1(supports-color@9.4.0)
-      debug: 4.3.4(supports-color@9.4.0)
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4816,7 +4831,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  index-to-position@0.1.2: {}
+  index-to-position@1.2.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -4927,7 +4942,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -5267,6 +5282,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@2.5.2: {}
 
   json-buffer@3.0.1: {}
@@ -5318,7 +5337,7 @@ snapshots:
     dependencies:
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       execa: 8.0.1
       lilconfig: 3.0.0
       listr2: 8.0.1
@@ -5351,8 +5370,6 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
-
-  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -5459,9 +5476,9 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.6:
+  minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.1
 
   minimatch@9.0.3:
     dependencies:
@@ -5485,13 +5502,11 @@ snapshots:
 
   ms@2.1.2: {}
 
+  ms@2.1.3: {}
+
   mute-stream@0.0.8: {}
 
   natural-compare@1.4.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-int64@0.4.0: {}
 
@@ -5519,17 +5534,15 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  openapi-typescript@7.4.2(typescript@5.4.2):
+  openapi-typescript@7.13.0(typescript@5.4.2):
     dependencies:
-      '@redocly/openapi-core': 1.25.11(supports-color@9.4.0)
+      '@redocly/openapi-core': 1.34.15(supports-color@10.2.2)
       ansi-colors: 4.1.3
       change-case: 5.4.4
-      parse-json: 8.1.0
-      supports-color: 9.4.0
+      parse-json: 8.3.0
+      supports-color: 10.2.2
       typescript: 5.4.2
       yargs-parser: 21.1.1
-    transitivePeerDependencies:
-      - encoding
 
   optionator@0.9.3:
     dependencies:
@@ -5603,11 +5616,11 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  parse-json@8.1.0:
+  parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.24.2
-      index-to-position: 0.1.2
-      type-fest: 4.26.1
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
 
   parse-passwd@1.0.0: {}
 
@@ -5939,6 +5952,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -5950,8 +5965,6 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
-
-  supports-color@9.4.0: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -5985,8 +5998,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  tr46@0.0.3: {}
 
   ts-api-utils@1.3.0(typescript@5.4.2):
     dependencies:
@@ -6023,7 +6034,7 @@ snapshots:
 
   type-fest@3.13.1: {}
 
-  type-fest@4.26.1: {}
+  type-fest@4.41.0: {}
 
   typedoc@0.27.9(typescript@5.4.2):
     dependencies:
@@ -6073,13 +6084,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@1.3.1:
     dependencies:

--- a/src/generatedApiTypes.ts
+++ b/src/generatedApiTypes.ts
@@ -11,7 +11,6 @@ export interface paths {
      * @description Get a detailed analysis of an individual identification event, including Smart Signals.
      *
      *     Use `event_id` as the URL path parameter. This API method is scoped to a request, i.e. all returned information is by `event_id`.
-     *
      */
     get: operations['getEvent']
     put?: never
@@ -30,7 +29,6 @@ export interface paths {
      *
      *     **Warning** Trying to update an event immediately after creation may temporarily result in an
      *     error (HTTP 409 Conflict. The event is not mutable yet.) as the event is fully propagated across our systems. In such a case, simply retry the request.
-     *
      */
     patch: operations['updateEvent']
     trace?: never
@@ -70,7 +68,6 @@ export interface paths {
      *     If you use a secret key that is scoped to an environment, you will only get events associated with the same environment. With a workspace-scoped environment, you will get events from all environments.
      *
      *     Smart Signals not activated for your workspace or are not included in the response.
-     *
      */
     get: operations['searchEvents']
     put?: never
@@ -120,7 +117,6 @@ export interface paths {
      *     The maximum number of DELETE requests that can be made in an hour cannot exceed 30 RPH, and the maximum number that can be made in a day cannot exceed 500 RPD.
      *
      *     You can request an increase to these limits by contacting [our support team](https://fingerprint.com/support/).
-     *
      */
     delete: operations['deleteVisitorData']
     options?: never
@@ -132,25 +128,33 @@ export interface paths {
 export type webhooks = Record<string, never>
 export interface components {
   schemas: {
-    /** @description A customer-provided id that was sent with the request. */
+    /**
+     * @description A customer-provided id that was sent with the request.
+     * @example somelinkedId
+     */
     LinkedId: string
     /** @description A customer-provided value or an object that was sent with the identification request or updated later. */
     Tags: {
       [key: string]: unknown
     }
-    /** @description Unique identifier of the user's request. The first portion of the event_id is a unix epoch milliseconds timestamp.
-     *      */
+    /**
+     * @description Unique identifier of the user's request. The first portion of the event_id is a unix epoch milliseconds timestamp.
+     * @example 1708102555327.NLOjmg
+     */
     EventId: string
     /**
      * Format: int64
      * @description Timestamp of the event with millisecond precision in Unix time.
+     * @example 1708102555327
      */
     Timestamp: number
-    /** @description Page URL from which the request was sent. */
+    /**
+     * @description Page URL from which the request was sent.
+     * @example https://www.example.com/login
+     */
     Url: string
     /**
      * @description The type and purpose of the bot.
-     *
      * @enum {string}
      */
     BotInfoCategory:
@@ -176,7 +180,6 @@ export interface components {
      *      * `signed` - bot that signs its platform via Web Bot Auth, directed by the bot provider's customers.
      *      * `spoofed` - bot that claims a public identity but fails verification.
      *      * `unknown` - bot that does not publish a verifiable identity.
-     *
      * @enum {string}
      */
     BotInfoIdentity: 'verified' | 'signed' | 'spoofed' | 'unknown'
@@ -187,14 +190,29 @@ export interface components {
     BotInfoConfidence: 'low' | 'medium' | 'high'
     /** @description Extended bot information. */
     BotInfo: {
-      /** @description The type and purpose of the bot.
-       *      */
+      /** @description The type and purpose of the bot. */
       category: string
-      /** @description The organization or company operating the bot. */
+      /**
+       * @description The organization or company operating the bot.
+       * @example Anthropic
+       * @example Browserbase
+       * @example Google
+       * @example OpenAI
+       */
       provider: string
-      /** @description The URL of the bot provider's website. */
+      /**
+       * @description The URL of the bot provider's website.
+       * @example https://fingerprint.com
+       */
       provider_url?: string
-      /** @description The specific name or identifier of the bot. */
+      /**
+       * @description The specific name or identifier of the bot.
+       * @example ClaudeBot
+       * @example Browserbase Agent
+       * @example Googlebot
+       * @example GPTBot
+       * @example ChatGPT-User
+       */
       name: string
       /**
        * @description The verification status of the bot's identity:
@@ -202,7 +220,6 @@ export interface components {
        *      * `signed` - bot that signs its platform via Web Bot Auth, directed by the bot provider's customers.
        *      * `spoofed` - bot that claims a public identity but fails verification.
        *      * `unknown` - bot that does not publish a verifiable identity.
-       *
        * @enum {string}
        */
       identity: 'verified' | 'signed' | 'spoofed' | 'unknown'
@@ -213,47 +230,123 @@ export interface components {
       confidence: 'low' | 'medium' | 'high'
     }
     Geolocation: {
-      /** @description The IP address is likely to be within this radius (in km) of the specified location. */
+      /**
+       * @description The IP address is likely to be within this radius (in km) of the specified location.
+       * @example 20
+       */
       accuracy_radius?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 50.05
+       */
       latitude?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 14.4
+       */
       longitude?: number
+      /** @example 150 00 */
       postal_code?: string
-      /** Format: timezone */
+      /**
+       * Format: timezone
+       * @example Europe/Prague
+       */
       timezone?: string
+      /** @example Prague */
       city_name?: string
+      /** @example CZ */
       country_code?: string
+      /** @example Czechia */
       country_name?: string
+      /** @example EU */
       continent_code?: string
+      /** @example Europe */
       continent_name?: string
       subdivisions?: {
+        /** @example 10 */
         iso_code: string
+        /** @example Hlavni mesto Praha */
         name: string
       }[]
     }
     IPInfoV4: {
-      /** Format: ipv4 */
+      /**
+       * Format: ipv4
+       * @example 94.142.239.124
+       */
       address: string
       geolocation?: components['schemas']['Geolocation']
+      /**
+       * @example 396982
+       * @example 16509
+       * @example 701
+       */
       asn?: string
+      /**
+       * @example Google LLC
+       * @example Amazon.com, Inc.
+       * @example Verizon Business
+       */
       asn_name?: string
+      /**
+       * @example 34.160.0.0/12
+       * @example 3.208.0.0/12
+       * @example 173.56.0.0/16
+       */
       asn_network?: string
+      /**
+       * @example hosting
+       * @example isp
+       * @example business
+       * @example education
+       */
       asn_type?: string
       /** @description When true, the request originated from a datacenter. */
       datacenter_result?: boolean
+      /**
+       * @example Google Cloud
+       * @example Amazon AWS
+       */
       datacenter_name?: string
     }
     IPInfoV6: {
-      /** Format: ipv6 */
+      /**
+       * Format: ipv6
+       * @example 2001:db8:3333:4444:5555:6666:7777:8888
+       */
       address: string
       geolocation?: components['schemas']['Geolocation']
+      /**
+       * @example 396982
+       * @example 16509
+       * @example 701
+       */
       asn?: string
+      /**
+       * @example Google LLC
+       * @example Amazon.com, Inc.
+       * @example Verizon Business
+       */
       asn_name?: string
+      /**
+       * @example 2001:4860:4801:10::/64
+       * @example 2600:1f00::/24
+       * @example 2001:4868:800::/40
+       */
       asn_network?: string
+      /**
+       * @example hosting
+       * @example isp
+       * @example business
+       * @example education
+       */
       asn_type?: string
       /** @description When true, the request originated from a datacenter. */
       datacenter_result?: boolean
+      /**
+       * @example Google Cloud
+       * @example Amazon AWS
+       */
       datacenter_name?: string
     }
     /** @description Details about the request IP address. Has separate fields for v4 and v6 IP address versions. */
@@ -261,12 +354,10 @@ export interface components {
       v4?: components['schemas']['IPInfoV4']
       v6?: components['schemas']['IPInfoV6']
     }
-    /** @description IP address was used by a public proxy provider or belonged to a known recent residential proxy
-     *      */
+    /** @description IP address was used by a public proxy provider or belonged to a known recent residential proxy */
     Proxy: boolean
     /**
      * @description Confidence level of the proxy detection. If a proxy is not detected, confidence is "high". If it's detected, can be "low", "medium", or "high".
-     *
      * @enum {string}
      */
     ProxyConfidence: 'low' | 'medium' | 'high'
@@ -277,23 +368,23 @@ export interface components {
        *      * `residential` - proxies that route through residential and telecom IP addresses to appear as legitimate traffic
        *      * `data_center` - proxies which route through data centers
        *      * `unknown` - reported when a proxy is detected solely by the ML model and the IP sources did not determine a specific type
-       *
        * @enum {string}
        */
       proxy_type: 'residential' | 'data_center' | 'unknown'
       /**
        * Format: int64
        * @description Unix millisecond timestamp with hourly resolution of when this IP was last seen as a proxy
-       *
+       * @example 1708102555327
        */
       last_seen_at?: number
-      /** @description String representing the last proxy service provider detected when this
+      /**
+       * @description String representing the last proxy service provider detected when this
        *     IP was synced. An IP can be shared by multiple service providers.
-       *      */
+       * @example Massive
+       */
       provider?: string
     }
-    /** @description VPN or other anonymizing service has been used when sending the request.
-     *      */
+    /** @description VPN or other anonymizing service has been used when sending the request. */
     Vpn: boolean
     /**
      * @description A confidence rating for the VPN detection result — "low", "medium", or "high". Depends on the combination of results returned from all VPN detection methods.
@@ -309,16 +400,16 @@ export interface components {
       auxiliary_mobile?: boolean
       /** @description The browser runs on a different operating system than the operating system inferred from the request network signature. */
       os_mismatch?: boolean
-      /** @description Request IP address belongs to a relay service provider, indicating the use of relay services like [Apple Private relay](https://support.apple.com/en-us/102602) or [Cloudflare Warp](https://developers.cloudflare.com/warp-client/).
+      /**
+       * @description Request IP address belongs to a relay service provider, indicating the use of relay services like [Apple Private relay](https://support.apple.com/en-us/102602) or [Cloudflare Warp](https://developers.cloudflare.com/warp-client/).
        *
        *     * Like VPNs, relay services anonymize the visitor's true IP address.
        *     * Unlike traditional VPNs, relay services don't let visitors spoof their location by choosing an exit node in a different country.
        *
        *     This field allows you to differentiate VPN users and relay service users in your fraud prevention logic.
-       *      */
+       */
       relay?: boolean
-      /** @description `true` if the request came from a device running a VPN, `false` otherwise.
-       *      */
+      /** @description `true` if the request came from a device running a VPN, `false` otherwise. */
       ml_prediction?: boolean
     }
     /**
@@ -346,7 +437,6 @@ export interface components {
      *     * `payload_too_large` - The request payload is too large and cannot be processed.
      *     * `service_unavailable` - The service was unable to process the request.
      *     * `ruleset_not_found` - The specified ruleset was not found. It never existed or it has been deleted.
-     *
      * @enum {string}
      */
     ErrorCode:
@@ -369,7 +459,8 @@ export interface components {
       | 'service_unavailable'
       | 'ruleset_not_found'
     Error: {
-      /** @description Error code:
+      /**
+       * @description Error code:
        *     * `request_cannot_be_parsed` - The query parameters or JSON payload contains some errors
        *       that prevented us from parsing it (wrong type/surpassed limits).
        *     * `request_read_timeout` - The request body could not be read before the connection timed out.
@@ -393,8 +484,9 @@ export interface components {
        *     * `payload_too_large` - The request payload is too large and cannot be processed.
        *     * `service_unavailable` - The service was unable to process the request.
        *     * `ruleset_not_found` - The specified ruleset was not found. It never existed or it has been deleted.
-       *      */
+       */
       code: components['schemas']['ErrorCode']
+      /** @example Forbidden */
       message: string
     }
     ErrorResponse: {
@@ -404,23 +496,37 @@ export interface components {
      * @description Only included for requests using incremental identification.
      *     - `partially_completed` - Indicates this event corresponds to a 'minimal' request. Smart Signals, even if included in your plan, are not computed; hence, their values must be ignored.
      *     - `completed` - Indicates this event corresponds to a 'complete' request. Smart Signals, if included in your plan, are computed; hence, their values are valid and relevant.
-     *
      * @enum {string}
      */
     IncrementalIdentificationStatus: 'partially_completed' | 'completed'
-    /** @description Environment Id of the event. */
+    /**
+     * @description Environment Id of the event.
+     * @example ae_47abaca3db2c7c43
+     */
     EnvironmentId: string
     /** @description Field is `true` if you have previously set the `suspect` flag for this event using the [Server API Update event endpoint](https://docs.fingerprint.com/reference/server-api-v4-update-event). */
     Suspect: boolean
     Integration: {
-      /** @description The name of the specific integration. */
+      /**
+       * @description The name of the specific integration.
+       * @example fingerprint-pro-react
+       */
       name?: string
-      /** @description The version of the specific integration. */
+      /**
+       * @description The version of the specific integration.
+       * @example 3.11.10
+       */
       version?: string
       subintegration?: {
-        /** @description The name of the specific subintegration. */
+        /**
+         * @description The name of the specific subintegration.
+         * @example preact
+         */
         name?: string
-        /** @description The version of the specific subintegration. */
+        /**
+         * @description The version of the specific subintegration.
+         * @example 10.21.0
+         */
         version?: string
       }
     }
@@ -431,105 +537,148 @@ export interface components {
        * @enum {string}
        */
       platform: 'js' | 'android' | 'ios' | 'unknown'
-      /** @description Version string of the SDK used for the identification request. */
+      /**
+       * @description Version string of the SDK used for the identification request.
+       * @example 3.11.10
+       */
       version: string
       integrations?: components['schemas']['Integration'][]
     }
-    /** @description `true` if we determined that this payload was replayed, `false` otherwise.
-     *      */
+    /** @description `true` if we determined that this payload was replayed, `false` otherwise. */
     Replayed: boolean
-    /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall).  */
+    /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall). */
     IdentificationConfidence: {
       /**
        * Format: double
        * @description A floating-point number between 0 and 1 that represents the probability of a false-positive identification. For High Recall ID, this value is 0.
+       * @example 0.97
        */
       score: number
-      /** @description The version name of the method used to calculate the confidence score. For High Recall ID, this value is "Not Supported".  */
+      /**
+       * @description The version name of the method used to calculate the confidence score. For High Recall ID, this value is "Not Supported".
+       * @example 1.1
+       */
       version?: string
+      /** @example Low confidence due to bot signals */
       comment?: string
     }
     Identification: {
-      /** @description String of 20 characters that uniquely identifies the visitor's browser or mobile device. */
+      /**
+       * @description String of 20 characters that uniquely identifies the visitor's browser or mobile device.
+       * @example Ibk1527CUFmcnjLwIs4A9
+       */
       visitor_id: string
-      /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall).  */
+      /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall). */
       confidence?: components['schemas']['IdentificationConfidence']
       /** @description Attribute represents if a visitor had been identified before. */
       visitor_found: boolean
       /**
        * Format: int64
        * @description Unix epoch time milliseconds timestamp indicating the time at which this visitor ID was first seen. example: `1758069706642` - Corresponding to Wed Sep 17 2025 00:41:46 GMT+0000
-       *
+       * @example 1708102555327
        */
       first_seen_at?: number
       /**
        * Format: int64
        * @description Unix epoch time milliseconds timestamp indicating the time at which this visitor ID was last seen. example: `1758069706642` - Corresponding to Wed Sep 17 2025 00:41:46 GMT+0000
-       *
+       * @example 1708102555327
        */
       last_seen_at?: number
     }
     /** @description The High Recall ID is a supplementary browser identifier designed for use cases that require wider coverage over precision. Compared to the standard visitor ID, the High Recall ID strives to match incoming browsers more generously (rather than precisely) with existing browsers and thus identifies fewer browsers as new. The High Recall ID is best suited for use cases that are sensitive to browsers being identified as new and where mismatched browsers are not detrimental. */
     SupplementaryIDHighRecall: {
-      /** @description The High Recall identifier for the visitor's browser. It is an alphanumeric string with a maximum length of 25 characters. */
+      /**
+       * @description The High Recall identifier for the visitor's browser. It is an alphanumeric string with a maximum length of 25 characters.
+       * @example 0jnGMkPYXX37DqVa4ZIO3f_hr
+       */
       visitor_id: string
       /** @description True if this is a returning browser and has been previously identified. Otherwise, false. */
       visitor_found: boolean
-      /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall).  */
+      /** @description The confidence score represents the probability of a false-positive identification. To learn more, visit [Confidence Score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence#confidence-score). Please note that the confidence score is not yet supported for [High Recall ID](https://docs.fingerprint.com/docs/supplementary-identifiers-highrecall). */
       confidence?: components['schemas']['IdentificationConfidence']
       /**
        * Format: int64
        * @description Unix epoch timestamp (in milliseconds) indicating when the browser was first identified. example: `1758069706642` - Corresponding to Wed Sep 17 2025 00:41:46 GMT+0000
-       *
+       * @example 1778086556130
        */
       first_seen_at?: number
       /**
        * Format: int64
        * @description Unix epoch timestamp (in milliseconds) corresponding to the most recent visit by this browser. example: `1758069706642` - Corresponding to Wed Sep 17 2025 00:41:46 GMT+0000
-       *
+       * @example 1778604975494
        */
       last_seen_at?: number
     }
-    /** @description Bundle Id of the iOS application integrated with the Fingerprint SDK for the event.
-     *      */
+    /**
+     * @description Bundle Id of the iOS application integrated with the Fingerprint SDK for the event.
+     * @example com.foo.app
+     */
     BundleId: string
-    /** @description Package name of the Android application integrated with the Fingerprint SDK for the event.
-     *      */
+    /**
+     * @description Package name of the Android application integrated with the Fingerprint SDK for the event.
+     * @example com.foo.app
+     */
     PackageName: string
-    /** @description IP address of the requesting browser or bot. */
+    /**
+     * @description IP address of the requesting browser or bot.
+     * @example 61.127.217.15
+     */
     IpAddress: string
-    /** @description User Agent of the client. */
+    /**
+     * @description User Agent of the client.
+     * @example Mozilla/5.0 (Windows NT 6.1; Win64; x64) ....
+     */
     UserAgent: string
-    /** @description Device model or family extracted from the user agent string. On web, this field is also present inside `browser_details`.
-     *      */
+    /**
+     * @description Device model or family extracted from the user agent string. On web, this field is also present inside `browser_details`.
+     * @example Generic Smartphone
+     * @example Desktop
+     * @example iPhone
+     */
     Device: string
-    /** @description Operating system family extracted from the user agent string. On web, this field is also present inside `browser_details`.
-     *      */
+    /**
+     * @description Operating system family extracted from the user agent string. On web, this field is also present inside `browser_details`.
+     * @example Windows
+     * @example iOS
+     * @example Android
+     */
     Os: string
-    /** @description Operating system version string extracted from the user agent string. On web, this field is also present inside `browser_details`.
-     *      */
+    /**
+     * @description Operating system version string extracted from the user agent string. On web, this field is also present inside `browser_details`.
+     * @example 17.4
+     * @example 14
+     * @example 10
+     */
     OsVersion: string
-    /** @description Client Referrer field corresponds to the `document.referrer` field gathered during an identification request. The value is an empty string if the user navigated to the page directly (not through a link, but, for example, by using a bookmark).
-     *      */
+    /**
+     * @description Client Referrer field corresponds to the `document.referrer` field gathered during an identification request. The value is an empty string if the user navigated to the page directly (not through a link, but, for example, by using a bookmark).
+     * @example https://example.com/blog/my-article
+     */
     ClientReferrer: string
     BrowserDetails: {
+      /** @example Chrome */
       browser_name: string
+      /** @example 74 */
       browser_major_version: string
+      /** @example 74.0.3729 */
       browser_full_version: string
+      /** @example Windows */
       os: string
+      /** @example 7 */
       os_version: string
+      /** @example Other */
       device: string
     }
-    /** @description Proximity ID represents a fixed geographical zone in a discrete global grid within which the device is observed.
-     *      */
+    /** @description Proximity ID represents a fixed geographical zone in a discrete global grid within which the device is observed. */
     Proximity: {
-      /** @description A stable privacy-preserving identifier for a given proximity zone.
-       *      */
+      /**
+       * @description A stable privacy-preserving identifier for a given proximity zone.
+       * @example w1aTfd4MCvl
+       */
       id: string
       /**
        * Format: int32
        * @description The radius of the proximity zone’s precision level, in meters.
-       *
        * @enum {integer}
        */
       precision_radius: 10 | 25 | 65 | 175 | 450 | 1200 | 3300 | 8500 | 22500
@@ -538,7 +687,7 @@ export interface components {
        * @description A value between `0` and `1` representing the likelihood that the true device location lies within the mapped proximity zone.
        *       * Scores closer to `1` indicate high confidence that the location is inside the mapped proximity zone.
        *       * Scores closer to `0` indicate lower confidence, suggesting the true location may fall in an adjacent zone.
-       *
+       * @example 0.95
        */
       confidence: number
     }
@@ -547,36 +696,39 @@ export interface components {
      *      * `bad` - bad bot detected, such as Selenium, Puppeteer, Playwright, headless browsers, and so on
      *      * `good` - good bot detected, such as Google bot, Baidu Spider, AlexaBot and so on
      *      * `not_detected` - the visitor is not a bot
-     *
      * @enum {string}
      */
     BotResult: 'bad' | 'good' | 'not_detected'
-    /** @description Additional classification of the bot type if detected.
-     *      */
+    /**
+     * @description Additional classification of the bot type if detected.
+     * @example fingerprint_agent
+     */
     BotType: string
-    /** @description Android specific cloned application detection. There are 2 values:
+    /**
+     * @description Android specific cloned application detection. There are 2 values:
      *     * `true` - Presence of app cloners work detected (e.g. fully cloned application found or launch of it inside of a not main working profile detected).
      *     * `false` - No signs of cloned application detected or the client is not Android.
-     *      */
+     */
     ClonedApp: boolean
-    /** @description `true` if the browser has DevTools open (Chrome, Firefox) or the Android/iOS device has Developer Tools enabled, `false` otherwise.
-     *      */
+    /** @description `true` if the browser has DevTools open (Chrome, Firefox) or the Android/iOS device has Developer Tools enabled, `false` otherwise. */
     DeveloperTools: boolean
-    /** @description Android specific emulator detection. There are 2 values:
+    /**
+     * @description Android specific emulator detection. There are 2 values:
      *     * `true` - Emulated environment detected (e.g. launch inside of AVD).
      *     * `false` - No signs of emulated environment detected or the client is not Android.
-     *      */
+     */
     Emulator: boolean
     /**
      * Format: int64
      * @description The time of the most recent factory reset that happened on the **mobile device** is expressed as Unix epoch time. When a factory reset cannot be detected on the mobile device or when the request is initiated from a browser,  this field will correspond to the *epoch* time (i.e 1 Jan 1970 UTC) as a value of 0. See [Factory Reset Detection](https://docs.fingerprint.com/docs/smart-signals-reference#factory-reset-detection) to learn more about this Smart Signal.
-     *
+     * @example 1708102555327
      */
     FactoryReset: number
-    /** @description [Frida](https://frida.re/docs/) detection for Android and iOS devices. There are 2 values:
+    /**
+     * @description [Frida](https://frida.re/docs/) detection for Android and iOS devices. There are 2 values:
      *     * `true` - Frida detected
      *     * `false` - No signs of Frida or the client is not a mobile device.
-     *      */
+     */
     Frida: boolean
     IPBlockList: {
       /** @description IP address was part of a known email spam attack (SMTP). */
@@ -589,37 +741,47 @@ export interface components {
     /**
      * Format: double
      * @description Machine learning–based proxy score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `proxy` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *
+     * @example 0.2
      */
     ProxyMLScore: number
-    /** @description `true` if we detected incognito mode used in the browser, `false` otherwise.
-     *      */
+    /** @description `true` if we detected incognito mode used in the browser, `false` otherwise. */
     Incognito: boolean
-    /** @description iOS specific jailbreak detection. There are 2 values:
+    /**
+     * @description iOS specific jailbreak detection. There are 2 values:
      *     * `true` - Jailbreak detected.
      *     * `false` - No signs of jailbreak or the client is not iOS.
-     *      */
+     */
     Jailbroken: boolean
     /** @description Flag indicating whether the request came from a mobile device with location spoofing enabled. */
     LocationSpoofing: boolean
-    /** @description * `true` - When requests made from your users' mobile devices to Fingerprint servers have been intercepted and potentially modified.
+    /**
+     * @description * `true` - When requests made from your users' mobile devices to Fingerprint servers have been intercepted and potentially modified.
      *     * `false` - Otherwise or when the request originated from a browser.
      *     See [MitM Attack Detection](https://docs.fingerprint.com/docs/smart-signals-reference#mitm-attack-detection) to learn more about this Smart Signal.
-     *      */
+     */
     MitMAttack: boolean
-    /** @description `true` if the request is from a privacy aware browser (e.g. Tor) or from a browser in which fingerprinting is blocked. Otherwise `false`.
-     *      */
+    /** @description `true` if the request is from a privacy aware browser (e.g. Tor) or from a browser in which fingerprinting is blocked. Otherwise `false`. */
     PrivacySettings: boolean
-    /** @description Android specific root management apps detection. There are 2 values:
+    /**
+     * @description Android specific root management apps detection. There are 2 values:
      *     * `true` - Root Management Apps detected (e.g. Magisk).
      *     * `false` - No Root Management Apps detected or the client isn't Android.
-     *      */
+     */
     RootApps: boolean
-    /** @description The ID of the evaluated ruleset. */
+    /**
+     * @description The ID of the evaluated ruleset.
+     * @example rs_b1k1blhqpOX3kU
+     */
     RulesetId: string
-    /** @description The ID of the rule that matched the identification event. */
+    /**
+     * @description The ID of the rule that matched the identification event.
+     * @example r_uE0af8497PFAOD
+     */
     RuleId: string
-    /** @description The expression of the rule that matched the identification event. */
+    /**
+     * @description The expression of the rule that matched the identification event.
+     * @example bot in ["bad"] || incognito
+     */
     RuleExpression: string
     /**
      * @description Describes the action to take with the request.
@@ -627,9 +789,15 @@ export interface components {
      */
     RuleActionType: 'allow' | 'block'
     RuleActionHeaderField: {
-      /** @description The header field name. */
+      /**
+       * @description The header field name.
+       * @example Content-Type
+       */
       name: string
-      /** @description The value of the header field. */
+      /**
+       * @description The value of the header field.
+       * @example application/json
+       */
       value: string
     }
     /** @description The set of header modifications to apply, in the following order: remove, set, append. */
@@ -657,9 +825,15 @@ export interface components {
       /** @description The set of header modifications to apply, in the following order: remove, set, append. */
       request_header_modifications?: components['schemas']['RequestHeaderModifications']
     }
-    /** @description A valid HTTP status code. */
+    /**
+     * @description A valid HTTP status code.
+     * @example 200
+     */
     StatusCode: number
-    /** @description The response body to send to the client. */
+    /**
+     * @description The response body to send to the client.
+     * @example {"title":"Forbidden"}
+     */
     RuleActionBody: string
     /** @description Informs the client the request should be blocked using the response described by this rule action. */
     EventRuleActionBlock: {
@@ -683,18 +857,22 @@ export interface components {
     }
     /** @description Describes the action the client should take, according to the rule in the ruleset that matched the event. When getting an event by event ID, the rule_action will only be included when the ruleset_id query parameter is specified. */
     EventRuleAction: components['schemas']['EventRuleActionAllow'] | components['schemas']['EventRuleActionBlock']
-    /** @description iOS specific simulator detection. There are 2 values:
+    /**
+     * @description iOS specific simulator detection. There are 2 values:
      *     * `true` - Simulator environment detected.
      *     * `false` - No signs of simulator or the client is not iOS.
-     *      */
+     */
     Simulator: boolean
-    /** @description Suspect Score is an easy way to integrate Smart Signals into your fraud protection work flow.  It is a weighted representation of all Smart Signals present in the payload that helps identify suspicious activity. The value range is [0; S] where S is sum of all Smart Signals weights.  See more details here: https://docs.fingerprint.com/docs/suspect-score
-     *      */
+    /**
+     * @description Suspect Score is an easy way to integrate Smart Signals into your fraud protection work flow.  It is a weighted representation of all Smart Signals present in the payload that helps identify suspicious activity. The value range is [0; S] where S is sum of all Smart Signals weights.  See more details here: https://docs.fingerprint.com/docs/suspect-score
+     * @example 8
+     */
     SuspectScore: number
-    /** @description The field can be used as a standalone flag for tampering detection. Alternatively, the more granular fields documented below can be used for workflows that require more context.
+    /**
+     * @description The field can be used as a standalone flag for tampering detection. Alternatively, the more granular fields documented below can be used for workflows that require more context.
      *     * `true` if tampering is detected through an anomalous browser signature, anti-detect browser detection, or other tampering-related methods
      *     * `false` if none of the tampering checks return a positive result
-     *      */
+     */
     Tampering: boolean
     /**
      * @description The confidence level indicates how certain Fingerprint is that the current request involves browser tampering. This confidence level is determined by evaluating multiple factors, such as heuristic rules, probabilistic anomaly detection, an anti detect browser ml model, and other relevant methods. It is conveyed as a string with possible values such as high, medium, or low
@@ -705,46 +883,52 @@ export interface components {
      *
      *     In case of tampering: `false`
      *     * **High confidence:** Strong signals suggest the user is not tampering with their request.
-     *
      * @enum {string}
      */
     TamperingConfidence: 'low' | 'medium' | 'high'
     /**
      * Format: double
      * @description The output of this model is captured as tampering_ml_score, a number indicating how likely an event is coming from an anti detect browser. Values close to 1 signify higher confidence and we consider anything above the threshold of 0.8 to be actionable (the result and anti_detect_browser fields conveniently captures that fact)
-     *
+     * @example 0.5
      */
     TamperingMlScore: number
     TamperingDetails: {
       /**
        * Format: double
        * @description The output of this model is captured as anomaly_score, a statistical score indicating how rare the visitor's browser signature is compared to the overall population. Values close to 1 signify highly anomalous browsers and we consider anything above the threshold of 0.5 to be actionable (the result field conveniently captures that fact).
-       *
+       * @example 0.5
        */
       anomaly_score?: number
-      /** @description Detects whether the request shows evidence of anti-detect browser usage.
+      /**
+       * @description Detects whether the request shows evidence of anti-detect browser usage.
        *     This field may be triggered by:
        *     * heuristic detection of known anti-detect browser behavior
        *     * machine learning detection of anti-detect browser patterns
        *
        *     Examples of anti-detect browsers include tools such as AdsPower, DolphinAnty, OctoBrowser, and GoLogin.
-       *      */
+       */
       anti_detect_browser?: boolean
     }
-    /** @description Is absent if the velocity data could not be generated for the visitor Id.
-     *      */
+    /** @description Is absent if the velocity data could not be generated for the visitor Id. */
     VelocityData: {
-      /** @description Count for the last 5 minutes of velocity data, from the time of the event.
-       *      */
+      /**
+       * @description Count for the last 5 minutes of velocity data, from the time of the event.
+       * @example 1
+       */
       '5_minutes': number
-      /** @description Count for the last 1 hour of velocity data, from the time of the event.
-       *      */
+      /**
+       * @description Count for the last 1 hour of velocity data, from the time of the event.
+       * @example 5
+       */
       '1_hour': number
-      /** @description The `24_hours` interval of `distinct_ip`, `distinct_linked_id`, `distinct_country`, `distinct_ip_by_linked_id` and `distinct_visitor_id_by_linked_id` will be omitted if the number of `events` for the visitor Id in the last 24 hours (`events.['24_hours']`) is higher than 20.000.
-       *      */
+      /**
+       * @description The `24_hours` interval of `distinct_ip`, `distinct_linked_id`, `distinct_country`, `distinct_ip_by_linked_id` and `distinct_visitor_id_by_linked_id` will be omitted if the number of `events` for the visitor Id in the last 24 hours (`events.['24_hours']`) is higher than 20.000.
+       * @example 5
+       */
       '24_hours'?: number
     }
-    /** @description Sums key data points for a specific `visitor_id`, `ip_address` and `linked_id` at three distinct time
+    /**
+     * @description Sums key data points for a specific `visitor_id`, `ip_address` and `linked_id` at three distinct time
      *     intervals: 5 minutes, 1 hour, and 24 hours as follows:
      *
      *     - Number of distinct IP addresses associated to the visitor Id.
@@ -762,139 +946,210 @@ export interface components {
      *
      *     All will not necessarily be returned in a response, some may be omitted if the
      *     associated event does not have the required data, such as a linked_id.
-     *      */
+     */
     Velocity: {
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       distinct_ip?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       distinct_linked_id?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       distinct_country?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       events?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       ip_events?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       distinct_ip_by_linked_id?: components['schemas']['VelocityData']
-      /** @description Is absent if the velocity data could not be generated for the visitor Id.
-       *      */
+      /** @description Is absent if the velocity data could not be generated for the visitor Id. */
       distinct_visitor_id_by_linked_id?: components['schemas']['VelocityData']
     }
-    /** @description `true` if the request came from a browser running inside a virtual machine (e.g. VMWare), `false` otherwise.
-     *      */
+    /** @description `true` if the request came from a browser running inside a virtual machine (e.g. VMWare), `false` otherwise. */
     VirtualMachine: boolean
     /**
      * Format: double
      * @description Machine learning–based virtual machine score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `virtual_machine` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *
+     * @example 0.5
      */
     VirtualMachineMLScore: number
     /**
      * Format: double
      * @description Machine learning–based VPN score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `vpn` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *
+     * @example 0.2
      */
     VpnMLScore: number
-    /** @description Local timezone which is used in timezone_mismatch method.
-     *      */
+    /**
+     * @description Local timezone which is used in timezone_mismatch method.
+     * @example Europe/Berlin
+     */
     VpnOriginTimezone: string
-    /** @description Country of the request (only for Android SDK version >= 2.4.0, ISO 3166 format or unknown).
-     *      */
+    /**
+     * @description Country of the request (only for Android SDK version >= 2.4.0, ISO 3166 format or unknown).
+     * @example DE
+     */
     VpnOriginCountry: string
     /** @description Flag indicating if the request came from a high-activity visitor. */
     HighActivity: boolean
-    /** @description `true` if the device is considered rare based on its combination of hardware and software attributes.  A device is classified as rare if it falls within the top 99.9 percentile (lowest-frequency segment) of observed traffic,  or if its configuration has not been previously seen (`not_seen`).
+    /**
+     * @description `true` if the device is considered rare based on its combination of hardware and software attributes.  A device is classified as rare if it falls within the top 99.9 percentile (lowest-frequency segment) of observed traffic,  or if its configuration has not been previously seen (`not_seen`).
      *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *      */
+     */
     RareDevice: boolean
     /**
      * @description The rarity percentile bucket of the device, indicating how uncommon the device configuration is compared to all observed devices.
      *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *
      * @enum {string}
      */
     RareDevicePercentileBucket: '<p95' | 'p95-p99' | 'p99-p99.5' | 'p99.5-p99.9' | 'p99.9+' | 'not_seen'
-    /** @description Baseline measurement of canonical fonts rendered on the device. Numeric width metrics, in CSS pixels, for the canonical fonts collected by the agent.
-     *      */
+    /** @description Baseline measurement of canonical fonts rendered on the device. Numeric width metrics, in CSS pixels, for the canonical fonts collected by the agent. */
     FontPreferences: {
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 147.5625
+       */
       default?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 147.5625
+       */
       serif?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 144.015625
+       */
       sans?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 133.0625
+       */
       mono?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 147.5625
+       */
       apple?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 9.234375
+       */
       min?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 146.09375
+       */
       system?: number
     }
     /** @description Bounding box metrics describing how the emoji glyph renders. */
     Emoji: {
-      /** @description Font family reported by the browser when drawing the emoji. */
+      /**
+       * @description Font family reported by the browser when drawing the emoji.
+       * @example Times
+       */
       font?: string
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 1600
+       */
       width?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 18
+       */
       height?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 14
+       */
       top?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 32
+       */
       bottom?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 8
+       */
       left?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 1608
+       */
       right?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 8
+       */
       x?: number
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 14
+       */
       y?: number
     }
-    /** @description List of fonts detected on the device. */
+    /**
+     * @description List of fonts detected on the device.
+     * @example [
+     *       "Arial Unicode MS",
+     *       "Gill Sans",
+     *       "Helvetica Neue",
+     *       "Menlo"
+     *     ]
+     */
     Fonts: string[]
     /**
      * Format: int32
      * @description Rounded amount of RAM in gigabytes.
+     * @example 8
      */
     DeviceMemory: number
-    /** @description Timezone identifier detected on the client. */
+    /**
+     * @description Timezone identifier detected on the client.
+     * @example America/Sao_Paulo
+     */
     Timezone: string
     /** @description Canvas fingerprint containing winding flag plus geometry/text hashes. */
     Canvas: {
       winding?: boolean
-      /** @description Hash of geometry rendering output or `unsupported` markers. */
+      /**
+       * @description Hash of geometry rendering output or `unsupported` markers.
+       * @example db3c1462576a399a03ae93d0ab9eb5c4
+       */
       geometry?: string
-      /** @description Hash of text rendering output or `unsupported` markers. */
+      /**
+       * @description Hash of text rendering output or `unsupported` markers.
+       * @example 70c3d3f7eb4408dc37a6bf8af1c51029
+       */
       text?: string
     }
-    /** @description Navigator languages reported by the agent including fallbacks. Each inner array represents ordered language preferences reported by different APIs. Available for browsers, iOS, and Android devices.
-     *      */
+    /** @description Navigator languages reported by the agent including fallbacks. Each inner array represents ordered language preferences reported by different APIs. Available for browsers, iOS, and Android devices. */
     Languages: string[][]
     /** @description Hashes of WebGL context attributes and extension support. */
     WebGlExtensions: {
+      /** @example 6b1ed336830d2bc96442a9d76373252a */
       context_attributes?: string
+      /** @example ea118c48e308bc4b0677118bbb3019ec */
       parameters?: string
+      /** @example f223dfbcd580cf142da156d93790eb83 */
       shader_precisions?: string
+      /** @example 57233d7b10f89fcd1ff95e3837ccd72d */
       extensions?: string
+      /** @example 86a8abb36f0cb30b5946dec0c761d042 */
       extension_parameters?: string
       unsupported_extensions?: string[]
     }
     /** @description Render and vendor strings reported by the WebGL context. */
     WebGlBasics: {
+      /** @example WebGL 1.0 (OpenGL ES 2.0 Chromium) */
       version?: string
+      /** @example WebKit */
       vendor?: string
+      /** @example Google Inc. (Apple) */
       vendor_unmasked?: string
+      /** @example WebKit WebGL */
       renderer?: string
+      /** @example ANGLE (Apple, ANGLE Metal Renderer: Apple M4, Unspecified Version) */
       renderer_unmasked?: string
+      /** @example WebGL GLSL ES 1.0 (OpenGL ES GLSL ES 1.0 Chromium) */
       shading_language_version?: string
     }
     /** @description Current screen resolution. Available for both browsers and iOS devices */
@@ -903,14 +1158,21 @@ export interface components {
     TouchSupport: {
       touch_event?: boolean
       touch_start?: boolean
-      /** Format: int64 */
+      /**
+       * Format: int64
+       * @example 0
+       */
       max_touch_points?: number
     }
-    /** @description Navigator `oscpu` string. */
+    /**
+     * @description Navigator `oscpu` string.
+     * @example Windows NT 6.1; Win64; x64
+     */
     Oscpu: string
     /**
      * Format: int32
      * @description Integer representing the CPU architecture exposed by the browser.
+     * @example 127
      */
     Architecture: number
     /** @description Whether the cookies are enabled in the browser. */
@@ -918,22 +1180,32 @@ export interface components {
     /**
      * Format: int32
      * @description Number of logical CPU cores reported by the browser.
+     * @example 10
      */
     HardwareConcurrency: number
-    /** @description Locale derived from the Intl.DateTimeFormat API. Negative values indicate known error states. The negative statuses can be:
+    /**
+     * @description Locale derived from the Intl.DateTimeFormat API. Negative values indicate known error states. The negative statuses can be:
      *     - "-1": A permanent status for browsers that don't support Intl API.
      *     - "-2": A permanent status for browsers that don't supportDateTimeFormat constructor.
      *     - "-3": A permanent status for browsers in which DateTimeFormat locale is undefined or null.
-     *      */
+     * @example en-US
+     */
     DateTimeLocale: string
-    /** @description Navigator vendor string. */
+    /**
+     * @description Navigator vendor string.
+     * @example Google Inc.
+     */
     Vendor: string
     /**
      * Format: int32
      * @description Screen color depth in bits.
+     * @example 24
      */
     ColorDepth: number
-    /** @description Navigator platform string. */
+    /**
+     * @description Navigator platform string.
+     * @example MacIntel
+     */
     Platform: string
     /** @description Whether sessionStorage is available. */
     SessionStorage: boolean
@@ -945,43 +1217,62 @@ export interface components {
      *     - -1: A permanent status for those browsers which are known to always suspend audio context
      *     - -2: A permanent status for browsers that don't support the signal
      *     - -3: A temporary status that means that an unexpected timeout has happened
-     *
+     * @example 124.04347745512496
      */
     Audio: number
     /** @description Browser plugins reported by `navigator.plugins`. */
     Plugins: {
+      /** @example PDF Viewer */
       name: string
+      /** @example Portable Document Format */
       description?: string
       mimeTypes?: {
+        /** @example application/pdf */
         type?: string
+        /** @example pdf */
         suffixes?: string
+        /** @example Portable Document Format */
         description?: string
       }[]
     }[]
     /** @description Whether IndexedDB is available. */
     IndexedDb: boolean
-    /** @description Hash of Math APIs used for entropy collection. */
+    /**
+     * @description Hash of Math APIs used for entropy collection.
+     * @example 5f030fa7d2e5f9f757bfaf81642eb1a6
+     */
     Math: string
-    /** @description Device model string. Available only for Android and iOS devices. */
+    /**
+     * @description Device model string. Available only for Android and iOS devices.
+     * @example iPhone 15 Pro
+     */
     DeviceModel: string
-    /** @description Device manufacturer string. Available only for Android and iOS devices. */
+    /**
+     * @description Device manufacturer string. Available only for Android and iOS devices.
+     * @example Apple
+     */
     DeviceManufacturer: string
-    /** @description Unique identifier for the user’s installed fonts. */
+    /**
+     * @description Unique identifier for the user’s installed fonts.
+     * @example e9f96f6c0e2c0b3a7a8b1d2c3e4f5a6b
+     */
     FontHash: string
-    /** @description UTC offset in "±HH:MM" format derived from the detected IANA timezone. */
+    /**
+     * @description UTC offset in "±HH:MM" format derived from the detected IANA timezone.
+     * @example +02:00
+     */
     TimezoneOffset: string
     /**
      * Format: int32
      * @description Battery charge level as a percentage (0-100). Available only for Android and iOS devices.
+     * @example 75
      */
     BatteryLevel: number
     /** @description Whether the device's low power mode is enabled. Available only for Android and iOS devices. */
     BatteryLowPowerMode: boolean
-    /** @description A curated subset of raw browser/device attributes that the API surface exposes. Each property contains a value or object with the data for the collected signal.
-     *      */
+    /** @description A curated subset of raw browser/device attributes that the API surface exposes. Each property contains a value or object with the data for the collected signal. */
     RawDeviceAttributes: {
-      /** @description Baseline measurement of canonical fonts rendered on the device. Numeric width metrics, in CSS pixels, for the canonical fonts collected by the agent.
-       *      */
+      /** @description Baseline measurement of canonical fonts rendered on the device. Numeric width metrics, in CSS pixels, for the canonical fonts collected by the agent. */
       font_preferences?: components['schemas']['FontPreferences']
       /** @description Bounding box metrics describing how the emoji glyph renders. */
       emoji?: components['schemas']['Emoji']
@@ -993,8 +1284,7 @@ export interface components {
       timezone?: components['schemas']['Timezone']
       /** @description Canvas fingerprint containing winding flag plus geometry/text hashes. */
       canvas?: components['schemas']['Canvas']
-      /** @description Navigator languages reported by the agent including fallbacks. Each inner array represents ordered language preferences reported by different APIs. Available for browsers, iOS, and Android devices.
-       *      */
+      /** @description Navigator languages reported by the agent including fallbacks. Each inner array represents ordered language preferences reported by different APIs. Available for browsers, iOS, and Android devices. */
       languages?: components['schemas']['Languages']
       /** @description Hashes of WebGL context attributes and extension support. */
       webgl_extensions?: components['schemas']['WebGlExtensions']
@@ -1012,11 +1302,12 @@ export interface components {
       cookies_enabled?: components['schemas']['CookiesEnabled']
       /** @description Number of logical CPU cores reported by the browser. */
       hardware_concurrency?: components['schemas']['HardwareConcurrency']
-      /** @description Locale derived from the Intl.DateTimeFormat API. Negative values indicate known error states. The negative statuses can be:
+      /**
+       * @description Locale derived from the Intl.DateTimeFormat API. Negative values indicate known error states. The negative statuses can be:
        *     - "-1": A permanent status for browsers that don't support Intl API.
        *     - "-2": A permanent status for browsers that don't supportDateTimeFormat constructor.
        *     - "-3": A permanent status for browsers in which DateTimeFormat locale is undefined or null.
-       *      */
+       */
       date_time_locale?: components['schemas']['DateTimeLocale']
       /** @description Navigator vendor string. */
       vendor?: components['schemas']['Vendor']
@@ -1028,11 +1319,12 @@ export interface components {
       session_storage?: components['schemas']['SessionStorage']
       /** @description Whether localStorage is available. */
       local_storage?: components['schemas']['LocalStorage']
-      /** @description AudioContext fingerprint or negative status when unavailable. The negative statuses can be:
+      /**
+       * @description AudioContext fingerprint or negative status when unavailable. The negative statuses can be:
        *     - -1: A permanent status for those browsers which are known to always suspend audio context
        *     - -2: A permanent status for browsers that don't support the signal
        *     - -3: A temporary status that means that an unexpected timeout has happened
-       *      */
+       */
       audio?: components['schemas']['Audio']
       /** @description Browser plugins reported by `navigator.plugins`. */
       plugins?: components['schemas']['Plugins']
@@ -1053,25 +1345,28 @@ export interface components {
       /** @description Whether the device's low power mode is enabled. Available only for Android and iOS devices. */
       battery_low_power_mode?: components['schemas']['BatteryLowPowerMode']
     }
-    /** @description Each label returns a prediction (true or false) for a specific use case (label field) based on a machine learning score. The machine learning score is determined by a model trained on customer data for that use case. This field is in the beta phase and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *      */
+    /** @description Each label returns a prediction (true or false) for a specific use case (label field) based on a machine learning score. The machine learning score is determined by a model trained on customer data for that use case. This field is in the beta phase and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/). */
     Labels: {
+      /** @example automation_tool */
       label: string
       prediction?: boolean
-      /** Format: double */
+      /**
+       * Format: double
+       * @example 0.95
+       */
       ml_score?: number
     }[]
     /** @description Contains results from Fingerprint Identification and all active Smart Signals. */
     Event: {
-      /** @description Unique identifier of the user's request. The first portion of the event_id is a unix epoch milliseconds timestamp.
-       *      */
+      /** @description Unique identifier of the user's request. The first portion of the event_id is a unix epoch milliseconds timestamp. */
       event_id: components['schemas']['EventId']
       /** @description Timestamp of the event with millisecond precision in Unix time. */
       timestamp: components['schemas']['Timestamp']
-      /** @description Only included for requests using incremental identification.
+      /**
+       * @description Only included for requests using incremental identification.
        *     - `partially_completed` - Indicates this event corresponds to a 'minimal' request. Smart Signals, even if included in your plan, are not computed; hence, their values must be ignored.
        *     - `completed` - Indicates this event corresponds to a 'complete' request. Smart Signals, if included in your plan, are computed; hence, their values are valid and relevant.
-       *      */
+       */
       incremental_identification_status?: components['schemas']['IncrementalIdentificationStatus']
       /** @description A customer-provided id that was sent with the request. */
       linked_id?: components['schemas']['LinkedId']
@@ -1081,8 +1376,7 @@ export interface components {
       suspect?: components['schemas']['Suspect']
       /** @description Contains information about the SDK used to perform the request. */
       sdk?: components['schemas']['SDK']
-      /** @description `true` if we determined that this payload was replayed, `false` otherwise.
-       *      */
+      /** @description `true` if we determined that this payload was replayed, `false` otherwise. */
       replayed?: components['schemas']['Replayed']
       identification?: components['schemas']['Identification']
       /** @description The High Recall ID is a supplementary browser identifier designed for use cases that require wider coverage over precision. Compared to the standard visitor ID, the High Recall ID strives to match incoming browsers more generously (rather than precisely) with existing browsers and thus identifies fewer browsers as new. The High Recall ID is best suited for use cases that are sensitive to browsers being identified as new and where mismatched browsers are not detrimental. */
@@ -1091,117 +1385,111 @@ export interface components {
       tags?: components['schemas']['Tags']
       /** @description Page URL from which the request was sent. */
       url?: components['schemas']['Url']
-      /** @description Bundle Id of the iOS application integrated with the Fingerprint SDK for the event.
-       *      */
+      /** @description Bundle Id of the iOS application integrated with the Fingerprint SDK for the event. */
       bundle_id?: components['schemas']['BundleId']
-      /** @description Package name of the Android application integrated with the Fingerprint SDK for the event.
-       *      */
+      /** @description Package name of the Android application integrated with the Fingerprint SDK for the event. */
       package_name?: components['schemas']['PackageName']
       /** @description IP address of the requesting browser or bot. */
       ip_address?: components['schemas']['IpAddress']
       /** @description User Agent of the client. */
       user_agent?: components['schemas']['UserAgent']
-      /** @description Device model or family extracted from the user agent string. On web, this field is also present inside `browser_details`.
-       *      */
+      /** @description Device model or family extracted from the user agent string. On web, this field is also present inside `browser_details`. */
       device?: components['schemas']['Device']
-      /** @description Operating system family extracted from the user agent string. On web, this field is also present inside `browser_details`.
-       *      */
+      /** @description Operating system family extracted from the user agent string. On web, this field is also present inside `browser_details`. */
       os?: components['schemas']['Os']
-      /** @description Operating system version string extracted from the user agent string. On web, this field is also present inside `browser_details`.
-       *      */
+      /** @description Operating system version string extracted from the user agent string. On web, this field is also present inside `browser_details`. */
       os_version?: components['schemas']['OsVersion']
-      /** @description Client Referrer field corresponds to the `document.referrer` field gathered during an identification request. The value is an empty string if the user navigated to the page directly (not through a link, but, for example, by using a bookmark).
-       *      */
+      /** @description Client Referrer field corresponds to the `document.referrer` field gathered during an identification request. The value is an empty string if the user navigated to the page directly (not through a link, but, for example, by using a bookmark). */
       client_referrer?: components['schemas']['ClientReferrer']
       browser_details?: components['schemas']['BrowserDetails']
-      /** @description Proximity ID represents a fixed geographical zone in a discrete global grid within which the device is observed.
-       *      */
+      /** @description Proximity ID represents a fixed geographical zone in a discrete global grid within which the device is observed. */
       proximity?: components['schemas']['Proximity']
-      /** @description Bot detection result:
+      /**
+       * @description Bot detection result:
        *      * `bad` - bad bot detected, such as Selenium, Puppeteer, Playwright, headless browsers, and so on
        *      * `good` - good bot detected, such as Google bot, Baidu Spider, AlexaBot and so on
        *      * `not_detected` - the visitor is not a bot
-       *      */
+       */
       bot?: components['schemas']['BotResult']
-      /** @description Additional classification of the bot type if detected.
-       *      */
+      /** @description Additional classification of the bot type if detected. */
       bot_type?: components['schemas']['BotType']
       /** @description Extended bot information. */
       bot_info?: components['schemas']['BotInfo']
-      /** @description Android specific cloned application detection. There are 2 values:
+      /**
+       * @description Android specific cloned application detection. There are 2 values:
        *     * `true` - Presence of app cloners work detected (e.g. fully cloned application found or launch of it inside of a not main working profile detected).
        *     * `false` - No signs of cloned application detected or the client is not Android.
-       *      */
+       */
       cloned_app?: components['schemas']['ClonedApp']
-      /** @description `true` if the browser has DevTools open (Chrome, Firefox) or the Android/iOS device has Developer Tools enabled, `false` otherwise.
-       *      */
+      /** @description `true` if the browser has DevTools open (Chrome, Firefox) or the Android/iOS device has Developer Tools enabled, `false` otherwise. */
       developer_tools?: components['schemas']['DeveloperTools']
-      /** @description Android specific emulator detection. There are 2 values:
+      /**
+       * @description Android specific emulator detection. There are 2 values:
        *     * `true` - Emulated environment detected (e.g. launch inside of AVD).
        *     * `false` - No signs of emulated environment detected or the client is not Android.
-       *      */
+       */
       emulator?: components['schemas']['Emulator']
-      /** @description The time of the most recent factory reset that happened on the **mobile device** is expressed as Unix epoch time. When a factory reset cannot be detected on the mobile device or when the request is initiated from a browser,  this field will correspond to the *epoch* time (i.e 1 Jan 1970 UTC) as a value of 0. See [Factory Reset Detection](https://docs.fingerprint.com/docs/smart-signals-reference#factory-reset-detection) to learn more about this Smart Signal.
-       *      */
+      /** @description The time of the most recent factory reset that happened on the **mobile device** is expressed as Unix epoch time. When a factory reset cannot be detected on the mobile device or when the request is initiated from a browser,  this field will correspond to the *epoch* time (i.e 1 Jan 1970 UTC) as a value of 0. See [Factory Reset Detection](https://docs.fingerprint.com/docs/smart-signals-reference#factory-reset-detection) to learn more about this Smart Signal. */
       factory_reset_timestamp?: components['schemas']['FactoryReset']
-      /** @description [Frida](https://frida.re/docs/) detection for Android and iOS devices. There are 2 values:
+      /**
+       * @description [Frida](https://frida.re/docs/) detection for Android and iOS devices. There are 2 values:
        *     * `true` - Frida detected
        *     * `false` - No signs of Frida or the client is not a mobile device.
-       *      */
+       */
       frida?: components['schemas']['Frida']
       ip_blocklist?: components['schemas']['IPBlockList']
       /** @description Details about the request IP address. Has separate fields for v4 and v6 IP address versions. */
       ip_info?: components['schemas']['IPInfo']
-      /** @description IP address was used by a public proxy provider or belonged to a known recent residential proxy
-       *      */
+      /** @description IP address was used by a public proxy provider or belonged to a known recent residential proxy */
       proxy?: components['schemas']['Proxy']
-      /** @description Confidence level of the proxy detection. If a proxy is not detected, confidence is "high". If it's detected, can be "low", "medium", or "high".
-       *      */
+      /** @description Confidence level of the proxy detection. If a proxy is not detected, confidence is "high". If it's detected, can be "low", "medium", or "high". */
       proxy_confidence?: components['schemas']['ProxyConfidence']
       /** @description Proxy detection details (present if `proxy` is `true`) */
       proxy_details?: components['schemas']['ProxyDetails']
-      /** @description Machine learning–based proxy score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `proxy` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+      /** @description Machine learning–based proxy score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `proxy` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/). */
       proxy_ml_score?: components['schemas']['ProxyMLScore']
-      /** @description `true` if we detected incognito mode used in the browser, `false` otherwise.
-       *      */
+      /** @description `true` if we detected incognito mode used in the browser, `false` otherwise. */
       incognito?: components['schemas']['Incognito']
-      /** @description iOS specific jailbreak detection. There are 2 values:
+      /**
+       * @description iOS specific jailbreak detection. There are 2 values:
        *     * `true` - Jailbreak detected.
        *     * `false` - No signs of jailbreak or the client is not iOS.
-       *      */
+       */
       jailbroken?: components['schemas']['Jailbroken']
       /** @description Flag indicating whether the request came from a mobile device with location spoofing enabled. */
       location_spoofing?: components['schemas']['LocationSpoofing']
-      /** @description * `true` - When requests made from your users' mobile devices to Fingerprint servers have been intercepted and potentially modified.
+      /**
+       * @description * `true` - When requests made from your users' mobile devices to Fingerprint servers have been intercepted and potentially modified.
        *     * `false` - Otherwise or when the request originated from a browser.
        *     See [MitM Attack Detection](https://docs.fingerprint.com/docs/smart-signals-reference#mitm-attack-detection) to learn more about this Smart Signal.
-       *      */
+       */
       mitm_attack?: components['schemas']['MitMAttack']
-      /** @description `true` if the request is from a privacy aware browser (e.g. Tor) or from a browser in which fingerprinting is blocked. Otherwise `false`.
-       *      */
+      /** @description `true` if the request is from a privacy aware browser (e.g. Tor) or from a browser in which fingerprinting is blocked. Otherwise `false`. */
       privacy_settings?: components['schemas']['PrivacySettings']
-      /** @description Android specific root management apps detection. There are 2 values:
+      /**
+       * @description Android specific root management apps detection. There are 2 values:
        *     * `true` - Root Management Apps detected (e.g. Magisk).
        *     * `false` - No Root Management Apps detected or the client isn't Android.
-       *      */
+       */
       root_apps?: components['schemas']['RootApps']
       /** @description Describes the action the client should take, according to the rule in the ruleset that matched the event. When getting an event by event ID, the rule_action will only be included when the ruleset_id query parameter is specified. */
       rule_action?: components['schemas']['EventRuleAction']
-      /** @description iOS specific simulator detection. There are 2 values:
+      /**
+       * @description iOS specific simulator detection. There are 2 values:
        *     * `true` - Simulator environment detected.
        *     * `false` - No signs of simulator or the client is not iOS.
-       *      */
+       */
       simulator?: components['schemas']['Simulator']
-      /** @description Suspect Score is an easy way to integrate Smart Signals into your fraud protection work flow.  It is a weighted representation of all Smart Signals present in the payload that helps identify suspicious activity. The value range is [0; S] where S is sum of all Smart Signals weights.  See more details here: https://docs.fingerprint.com/docs/suspect-score
-       *      */
+      /** @description Suspect Score is an easy way to integrate Smart Signals into your fraud protection work flow.  It is a weighted representation of all Smart Signals present in the payload that helps identify suspicious activity. The value range is [0; S] where S is sum of all Smart Signals weights.  See more details here: https://docs.fingerprint.com/docs/suspect-score */
       suspect_score?: components['schemas']['SuspectScore']
-      /** @description The field can be used as a standalone flag for tampering detection. Alternatively, the more granular fields documented below can be used for workflows that require more context.
+      /**
+       * @description The field can be used as a standalone flag for tampering detection. Alternatively, the more granular fields documented below can be used for workflows that require more context.
        *     * `true` if tampering is detected through an anomalous browser signature, anti-detect browser detection, or other tampering-related methods
        *     * `false` if none of the tampering checks return a positive result
-       *      */
+       */
       tampering?: components['schemas']['Tampering']
-      /** @description The confidence level indicates how certain Fingerprint is that the current request involves browser tampering. This confidence level is determined by evaluating multiple factors, such as heuristic rules, probabilistic anomaly detection, an anti detect browser ml model, and other relevant methods. It is conveyed as a string with possible values such as high, medium, or low
+      /**
+       * @description The confidence level indicates how certain Fingerprint is that the current request involves browser tampering. This confidence level is determined by evaluating multiple factors, such as heuristic rules, probabilistic anomaly detection, an anti detect browser ml model, and other relevant methods. It is conveyed as a string with possible values such as high, medium, or low
        *     In case of tampering: `true`
        *     * **High confidence**: heuristic anti detect browser signals and the ml model are triggered, or all of the methods are triggered.
        *     * **Medium confidence**: either the ml model triggers alone, the anomaly score triggers alone with or without the heuristic anti detect browser methods trigger.
@@ -1209,13 +1497,13 @@ export interface components {
        *
        *     In case of tampering: `false`
        *     * **High confidence:** Strong signals suggest the user is not tampering with their request.
-       *      */
+       */
       tampering_confidence?: components['schemas']['TamperingConfidence']
-      /** @description The output of this model is captured as tampering_ml_score, a number indicating how likely an event is coming from an anti detect browser. Values close to 1 signify higher confidence and we consider anything above the threshold of 0.8 to be actionable (the result and anti_detect_browser fields conveniently captures that fact)
-       *      */
+      /** @description The output of this model is captured as tampering_ml_score, a number indicating how likely an event is coming from an anti detect browser. Values close to 1 signify higher confidence and we consider anything above the threshold of 0.8 to be actionable (the result and anti_detect_browser fields conveniently captures that fact) */
       tampering_ml_score?: components['schemas']['TamperingMlScore']
       tampering_details?: components['schemas']['TamperingDetails']
-      /** @description Sums key data points for a specific `visitor_id`, `ip_address` and `linked_id` at three distinct time
+      /**
+       * @description Sums key data points for a specific `visitor_id`, `ip_address` and `linked_id` at three distinct time
        *     intervals: 5 minutes, 1 hour, and 24 hours as follows:
        *
        *     - Number of distinct IP addresses associated to the visitor Id.
@@ -1233,48 +1521,45 @@ export interface components {
        *
        *     All will not necessarily be returned in a response, some may be omitted if the
        *     associated event does not have the required data, such as a linked_id.
-       *      */
+       */
       velocity?: components['schemas']['Velocity']
-      /** @description `true` if the request came from a browser running inside a virtual machine (e.g. VMWare), `false` otherwise.
-       *      */
+      /** @description `true` if the request came from a browser running inside a virtual machine (e.g. VMWare), `false` otherwise. */
       virtual_machine?: components['schemas']['VirtualMachine']
-      /** @description Machine learning–based virtual machine score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `virtual_machine` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+      /** @description Machine learning–based virtual machine score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `virtual_machine` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/). */
       virtual_machine_ml_score?: components['schemas']['VirtualMachineMLScore']
-      /** @description VPN or other anonymizing service has been used when sending the request.
-       *      */
+      /** @description VPN or other anonymizing service has been used when sending the request. */
       vpn?: components['schemas']['Vpn']
       /** @description A confidence rating for the VPN detection result — "low", "medium", or "high". Depends on the combination of results returned from all VPN detection methods. */
       vpn_confidence?: components['schemas']['VpnConfidence']
-      /** @description Machine learning–based VPN score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `vpn` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+      /** @description Machine learning–based VPN score, represented as a floating-point value between 0 and 1 (inclusive), with up to three decimal places of precision. A higher score means a higher confidence in the positive `vpn` detection result. This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/). */
       vpn_ml_score?: components['schemas']['VpnMLScore']
-      /** @description Local timezone which is used in timezone_mismatch method.
-       *      */
+      /** @description Local timezone which is used in timezone_mismatch method. */
       vpn_origin_timezone?: components['schemas']['VpnOriginTimezone']
-      /** @description Country of the request (only for Android SDK version >= 2.4.0, ISO 3166 format or unknown).
-       *      */
+      /** @description Country of the request (only for Android SDK version >= 2.4.0, ISO 3166 format or unknown). */
       vpn_origin_country?: components['schemas']['VpnOriginCountry']
       vpn_methods?: components['schemas']['VpnMethods']
       /** @description Flag indicating if the request came from a high-activity visitor. */
       high_activity_device?: components['schemas']['HighActivity']
-      /** @description `true` if the device is considered rare based on its combination of hardware and software attributes.  A device is classified as rare if it falls within the top 99.9 percentile (lowest-frequency segment) of observed traffic,  or if its configuration has not been previously seen (`not_seen`).
+      /**
+       * @description `true` if the device is considered rare based on its combination of hardware and software attributes.  A device is classified as rare if it falls within the top 99.9 percentile (lowest-frequency segment) of observed traffic,  or if its configuration has not been previously seen (`not_seen`).
        *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+       */
       rare_device?: components['schemas']['RareDevice']
-      /** @description The rarity percentile bucket of the device, indicating how uncommon the device configuration is compared to all observed devices.
+      /**
+       * @description The rarity percentile bucket of the device, indicating how uncommon the device configuration is compared to all observed devices.
        *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+       */
       rare_device_percentile_bucket?: components['schemas']['RareDevicePercentileBucket']
-      /** @description A curated subset of raw browser/device attributes that the API surface exposes. Each property contains a value or object with the data for the collected signal.
-       *      */
+      /** @description A curated subset of raw browser/device attributes that the API surface exposes. Each property contains a value or object with the data for the collected signal. */
       raw_device_attributes?: components['schemas']['RawDeviceAttributes']
-      /** @description Each label returns a prediction (true or false) for a specific use case (label field) based on a machine learning score. The machine learning score is determined by a model trained on customer data for that use case. This field is in the beta phase and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-       *      */
+      /** @description Each label returns a prediction (true or false) for a specific use case (label field) based on a machine learning score. The machine learning score is determined by a model trained on customer data for that use case. This field is in the beta phase and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/). */
       labels?: components['schemas']['Labels']
     }
     EventUpdate: {
-      /** @description Linked ID value to assign to the existing event */
+      /**
+       * @description Linked ID value to assign to the existing event
+       * @example somelinkedId
+       */
       linked_id?: string
       /** @description A customer-provided value or an object that was sent with the identification request or updated later. */
       tags?: {
@@ -1286,11 +1571,15 @@ export interface components {
     /** @description Contains a list of all identification events matching the specified search criteria. */
     EventSearch: {
       events: components['schemas']['Event'][]
-      /** @description Use this value in the `pagination_key` parameter to request the next page of search results. */
+      /**
+       * @description Use this value in the `pagination_key` parameter to request the next page of search results.
+       * @example S9rgMMUb4z3X5t5pr_tSgoSZlmyF0O8X7kCV2m981-iY1LmRTjraa1rTk3L-hQExnDWCi0RA-zAIjaVSTNO2AN2eqQWgzT0RjbieMxRfSdkM-HmOhdOgdQvYfPG3vqU1DJKh4Q
+       */
       pagination_key?: string
       /**
        * Format: int64
        * @description This value represents the total number of events matching the search query, up to the limit provided in the `total_hits` query parameter. Only present if the `total_hits` query parameter was provided.
+       * @example 100
        */
       total_hits?: number
     }
@@ -1301,7 +1590,6 @@ export interface components {
      *       `bad` - events where a bad bot was detected.
      *       `none` - events where no bot was detected.
      *     > Note: When using this parameter, only events with the `bot` property set to a valid value are returned. Events without a `bot` Smart Signal result are left out of the response.
-     *
      * @enum {string}
      */
     SearchEventsBot: 'all' | 'good' | 'bad' | 'none'
@@ -1309,7 +1597,6 @@ export interface components {
      * @description Filter events by their Bot Info result, specifically:
      *       - `all` - events where any kind of bot was detected.
      *       - `none` - events where no bot was detected.
-     *
      * @enum {string}
      */
     SearchEventsBotInfo: 'all' | 'none'
@@ -1319,7 +1606,6 @@ export interface components {
      *     `medium` - events with medium VPN Detection confidence.
      *     `low` - events with low VPN Detection confidence.
      *     > Note: When using this parameter, only events with the `vpn.confidence` property set to a valid value are returned. Events without a `vpn` Smart Signal result are left out of the response.
-     *
      * @enum {string}
      */
     SearchEventsVpnConfidence: 'high' | 'medium' | 'low'
@@ -1333,7 +1619,6 @@ export interface components {
      *     `not_seen` - device configuration has never been observed before.
      *
      *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-     *
      * @enum {string}
      */
     SearchEventsRareDevicePercentileBucket: '<p95' | 'p95-p99' | 'p99-p99.5' | 'p99.5-p99.9' | 'p99.9+' | 'not_seen'
@@ -1342,13 +1627,11 @@ export interface components {
      *     `js` - Javascript agent (Web).
      *     `ios` - Apple iOS based devices.
      *     `android` - Android based devices.
-     *
      * @enum {string}
      */
     SearchEventsSdkPlatform: 'js' | 'android' | 'ios'
     /**
      * @description Filter events by their incremental identification status (`incremental_identification_status` property). Non incremental identification events are left out of the response.
-     *
      * @enum {string}
      */
     SearchEventsIncrementalIdentificationStatus: 'partially_completed' | 'completed'
@@ -1366,9 +1649,10 @@ export interface operations {
   getEvent: {
     parameters: {
       query?: {
-        /** @description The ID of the ruleset to evaluate against the event, producing the action to take for this event.
+        /**
+         * @description The ID of the ruleset to evaluate against the event, producing the action to take for this event.
          *     The resulting action is returned in the `rule_action` attribute of the response.
-         *      */
+         */
         ruleset_id?: string
       }
       header?: never
@@ -1500,181 +1784,206 @@ export interface operations {
   searchEvents: {
     parameters: {
       query?: {
-        /** @description Maximum number of events to return. Defaults to 10 when omitted. Results are selected from the time range (`start`, `end`), ordered by `reverse`, then truncated to provided `limit` size. So `reverse=true` returns the oldest N=`limit` events, otherwise the newest N=`limit` events.
-         *      */
+        /** @description Maximum number of events to return. Defaults to 10 when omitted. Results are selected from the time range (`start`, `end`), ordered by `reverse`, then truncated to provided `limit` size. So `reverse=true` returns the oldest N=`limit` events, otherwise the newest N=`limit` events. */
         limit?: number
-        /** @description Use `pagination_key` to get the next page of results.
+        /**
+         * @description Use `pagination_key` to get the next page of results.
          *
          *     When more results are available (e.g., you requested up to 100 results for your query using `limit`, but there are more than 100 events total matching your request), the `pagination_key` field is added to the response. The pagination key is an arbitrary string that should not be interpreted in any way and should be passed as-is. In the following request, use that value in the `pagination_key` parameter to get the next page of results:
          *
          *     1. First request, returning most recent 100 events: `GET api-base-url/events?limit=100`
          *     2. Use `response.pagination_key` to get the next page of results: `GET api-base-url/events?limit=100&pagination_key=S9rgMMUb4z3X5t5pr_tSgoSZlmyF0O8X7kCV2m981-iY1LmRTjraa1rTk3L-hQExnDWCi0RA-zAIjaVSTNO2AN2eqQWgzT0RjbieMxRfSdkM-HmOhdOgdQvYfPG3vqU1DJKh4Q`
-         *      */
+         */
         pagination_key?: string
-        /** @description Unique [visitor identifier](https://docs.fingerprint.com/reference/js-agent-v4-get-function#visitor_id) issued by Fingerprint Identification and all active Smart Signals.
+        /**
+         * @description Unique [visitor identifier](https://docs.fingerprint.com/reference/js-agent-v4-get-function#visitor_id) issued by Fingerprint Identification and all active Smart Signals.
          *
          *     Filter events by matching Visitor ID (`identification.visitor_id` property).
-         *      */
+         */
         visitor_id?: string
-        /** @description The High Recall ID is a supplementary browser identifier designed for use cases that require wider coverage over precision. Compared to the standard visitor ID, the High Recall ID strives to match incoming browsers more generously (rather than precisely) with existing browsers and thus identifies fewer browsers as new. The High Recall ID is best suited for use cases that are sensitive to browsers being identified as new and where mismatched browsers are not detrimental.
+        /**
+         * @description The High Recall ID is a supplementary browser identifier designed for use cases that require wider coverage over precision. Compared to the standard visitor ID, the High Recall ID strives to match incoming browsers more generously (rather than precisely) with existing browsers and thus identifies fewer browsers as new. The High Recall ID is best suited for use cases that are sensitive to browsers being identified as new and where mismatched browsers are not detrimental.
          *
          *     Filter events by matching High Recall ID (`supplementary_id_high_recall.visitor_id` property).
-         *      */
+         */
         high_recall_id?: string
-        /** @description Filter events by the Bot Detection result, specifically:
+        /**
+         * @description Filter events by the Bot Detection result, specifically:
          *       `all` - events where any kind of bot was detected.
          *       `good` - events where a good bot was detected.
          *       `bad` - events where a bad bot was detected.
          *       `none` - events where no bot was detected.
          *     > Note: When using this parameter, only events with the `bot` property set to a valid value are returned. Events without a `bot` Smart Signal result are left out of the response.
-         *      */
+         */
         bot?: components['schemas']['SearchEventsBot']
-        /** @description Filter events by their Bot Info result, specifically:
+        /**
+         * @description Filter events by their Bot Info result, specifically:
          *       - `all` - events where any kind of bot was detected.
          *       - `none` - events where no bot was detected.
-         *      */
+         */
         bot_info?: components['schemas']['SearchEventsBotInfo']
-        /** @description Filter events by their Bot Info Category.
+        /**
+         * @description Filter events by their Bot Info Category.
          *
          *     Multiple categories can be provided using the repeated keys syntax. For example, `bot_info_category=ai_agent&bot_info_category=ai_assistant`, will match events with a Bot Info Category of `ai_agent` or `ai_assistant`. Other notations like comma-separated or bracket notation are not supported.
-         *      */
+         */
         bot_info_category?: components['schemas']['BotInfoCategory'][]
-        /** @description Filter events by their Bot Info Identity type.
+        /**
+         * @description Filter events by their Bot Info Identity type.
          *
          *     Multiple identity types can be provided using the repeated keys syntax. For example, `bot_info_identity=verified&bot_info_identity=signed`, will match events with a Bot Info Identity of `verified` or `signed`. Other notations like comma-separated or bracket notation are not supported.
-         *      */
+         */
         bot_info_identity?: components['schemas']['BotInfoIdentity'][]
-        /** @description Filter events by their Bot Info Confidence.
+        /**
+         * @description Filter events by their Bot Info Confidence.
          *
          *     Multiple confidences can be provided using the repeated keys syntax. For example, `bot_info_confidence=high&bot_info_confidence=medium`, will match events with a Bot Info Confidence of `high` or `medium`. Other notations like comma-separated or bracket notation are not supported.
-         *      */
+         */
         bot_info_confidence?: components['schemas']['BotInfoConfidence'][]
-        /** @description Filter events by their Bot Info Provider. The provider must match exactly, partial or wildcard matching is not supported.
+        /**
+         * @description Filter events by their Bot Info Provider. The provider must match exactly, partial or wildcard matching is not supported.
          *
          *     Multiple Providers can be provided using the repeated keys syntax. For example, `bot_info_provider=OpenAI&bot_info_provider=AWS`, will match events with a Bot Info Provider of `OpenAI` or `AWS`. Other notations like comma-separated or bracket notation are not supported.
-         *      */
+         */
         bot_info_provider?: string[]
-        /** @description Filter events by their Bot Info Name. The name must match exactly, partial or wildcard matching is not supported.
+        /**
+         * @description Filter events by their Bot Info Name. The name must match exactly, partial or wildcard matching is not supported.
          *
          *     Multiple Names can be provided using the repeated keys syntax. For example, `bot_info_name=ChatGPT%20Agent&bot_info_name=Bedrock%20AgentCore`, will match events with a Bot Info Name of `ChatGPT Agent` or `Bedrock AgentCore`. Other notations like comma-separated or bracket notation are not supported.
-         *      */
+         */
         bot_info_name?: string[]
-        /** @description Filter events by IP address or IP range (if CIDR notation is used). If CIDR notation is not used, a /32 for IPv4 or /128 for IPv6 is assumed.
+        /**
+         * @description Filter events by IP address or IP range (if CIDR notation is used). If CIDR notation is not used, a /32 for IPv4 or /128 for IPv6 is assumed.
          *     Examples of range based queries: 10.0.0.0/24, 192.168.0.1/32
-         *      */
+         */
         ip_address?: string
-        /** @description Filter events by the ASN associated with the event's IP address.
+        /**
+         * @description Filter events by the ASN associated with the event's IP address.
          *     This corresponds to the `ip_info.(v4|v6).asn` property in the response.
-         *      */
+         */
         asn?: string
-        /** @description Filter events by your custom identifier.
+        /**
+         * @description Filter events by your custom identifier.
          *
          *     You can use [linked Ids](https://docs.fingerprint.com/reference/js-agent-v4-get-function#linkedid) to associate identification requests with your own identifier, for example, session Id, purchase Id, or transaction Id. You can then use this `linked_id` parameter to retrieve all events associated with your custom identifier.
-         *      */
+         */
         linked_id?: string
-        /** @description Filter events by the URL (`url` property) associated with the event.
-         *      */
+        /** @description Filter events by the URL (`url` property) associated with the event. */
         url?: string
-        /** @description Filter events by the Bundle ID (iOS) associated with the event.
-         *      */
+        /** @description Filter events by the Bundle ID (iOS) associated with the event. */
         bundle_id?: string
-        /** @description Filter events by the Package Name (Android) associated with the event.
-         *      */
+        /** @description Filter events by the Package Name (Android) associated with the event. */
         package_name?: string
-        /** @description Filter events by the origin field of the event. This is applicable to web events only (e.g., https://example.com)
-         *      */
+        /** @description Filter events by the origin field of the event. This is applicable to web events only (e.g., https://example.com) */
         origin?: string
-        /** @description Include events that happened after this point (with timestamp greater than or equal the provided `start` Unix milliseconds value or RFC3339 timestamp). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed.
-         *      */
+        /** @description Include events that happened after this point (with timestamp greater than or equal the provided `start` Unix milliseconds value or RFC3339 timestamp). Defaults to 7 days ago. Setting `start` does not change `end`'s default of `now` — adjust it separately if needed. */
         start?: number | string
-        /** @description Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value or RFC3339 timestamp). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed.
-         *      */
+        /** @description Include events that happened before this point (with timestamp less than or equal the provided `end` Unix milliseconds value or RFC3339 timestamp). Defaults to now. Setting `end` does not change `start`'s default of `7 days ago` — adjust it separately if needed. */
         end?: number | string
-        /** @description When `true`, sort events oldest first (ascending timestamp order). Defaults to `false` (newest first, descending timestamp order).
-         *      */
+        /** @description When `true`, sort events oldest first (ascending timestamp order). Defaults to `false` (newest first, descending timestamp order). */
         reverse?: boolean
-        /** @description Filter events previously tagged as suspicious via the [Update API](https://docs.fingerprint.com/reference/server-api-v4-update-event).
+        /**
+         * @description Filter events previously tagged as suspicious via the [Update API](https://docs.fingerprint.com/reference/server-api-v4-update-event).
          *     > Note: When using this parameter, only events with the `suspect` property explicitly set to `true` or `false` are returned. Events with undefined `suspect` property are left out of the response.
-         *      */
+         */
         suspect?: boolean
-        /** @description Filter events by VPN Detection result.
+        /**
+         * @description Filter events by VPN Detection result.
          *     > Note: When using this parameter, only events with the `vpn` property set to `true` or `false` are returned. Events without a `vpn` Smart Signal result are left out of the response.
-         *      */
+         */
         vpn?: boolean
-        /** @description Filter events by Virtual Machine Detection result.
+        /**
+         * @description Filter events by Virtual Machine Detection result.
          *     > Note: When using this parameter, only events with the `virtual_machine` property set to `true` or `false` are returned. Events without a `virtual_machine` Smart Signal result are left out of the response.
-         *      */
+         */
         virtual_machine?: boolean
-        /** @description Filter events by Browser Tampering Detection result.
+        /**
+         * @description Filter events by Browser Tampering Detection result.
          *     > Note: When using this parameter, only events with the `tampering.result` property set to `true` or `false` are returned. Events without a `tampering` Smart Signal result are left out of the response.
-         *      */
+         */
         tampering?: boolean
-        /** @description Filter events by Anti-detect Browser Detection result.
+        /**
+         * @description Filter events by Anti-detect Browser Detection result.
          *     > Note: When using this parameter, only events with the `tampering.anti_detect_browser` property set to `true` or `false` are returned. Events without a `tampering` Smart Signal result are left out of the response.
-         *      */
+         */
         anti_detect_browser?: boolean
-        /** @description Filter events by Browser Incognito Detection result.
+        /**
+         * @description Filter events by Browser Incognito Detection result.
          *     > Note: When using this parameter, only events with the `incognito` property set to `true` or `false` are returned. Events without an `incognito` Smart Signal result are left out of the response.
-         *      */
+         */
         incognito?: boolean
-        /** @description Filter events by Privacy Settings Detection result.
+        /**
+         * @description Filter events by Privacy Settings Detection result.
          *     > Note: When using this parameter, only events with the `privacy_settings` property set to `true` or `false` are returned. Events without a `privacy_settings` Smart Signal result are left out of the response.
-         *      */
+         */
         privacy_settings?: boolean
-        /** @description Filter events by Jailbroken Device Detection result.
+        /**
+         * @description Filter events by Jailbroken Device Detection result.
          *     > Note: When using this parameter, only events with the `jailbroken` property set to `true` or `false` are returned. Events without a `jailbroken` Smart Signal result are left out of the response.
-         *      */
+         */
         jailbroken?: boolean
-        /** @description Filter events by Frida Detection result.
+        /**
+         * @description Filter events by Frida Detection result.
          *     > Note: When using this parameter, only events with the `frida` property set to `true` or `false` are returned. Events without a `frida` Smart Signal result are left out of the response.
-         *      */
+         */
         frida?: boolean
-        /** @description Filter events by Factory Reset Detection result.
+        /**
+         * @description Filter events by Factory Reset Detection result.
          *     > Note: When using this parameter, only events with a `factory_reset` time. Events without a `factory_reset` Smart Signal result are left out of the response.
-         *      */
+         */
         factory_reset?: boolean
-        /** @description Filter events by Cloned App Detection result.
+        /**
+         * @description Filter events by Cloned App Detection result.
          *     > Note: When using this parameter, only events with the `cloned_app` property set to `true` or `false` are returned. Events without a `cloned_app` Smart Signal result are left out of the response.
-         *      */
+         */
         cloned_app?: boolean
-        /** @description Filter events by Android Emulator Detection result.
+        /**
+         * @description Filter events by Android Emulator Detection result.
          *     > Note: When using this parameter, only events with the `emulator` property set to `true` or `false` are returned. Events without an `emulator` Smart Signal result are left out of the response.
-         *      */
+         */
         emulator?: boolean
-        /** @description Filter events by Rooted Device Detection result.
+        /**
+         * @description Filter events by Rooted Device Detection result.
          *     > Note: When using this parameter, only events with the `root_apps` property set to `true` or `false` are returned. Events without a `root_apps` Smart Signal result are left out of the response.
-         *      */
+         */
         root_apps?: boolean
-        /** @description Filter events by VPN Detection result confidence level.
+        /**
+         * @description Filter events by VPN Detection result confidence level.
          *     `high` - events with high VPN Detection confidence.
          *     `medium` - events with medium VPN Detection confidence.
          *     `low` - events with low VPN Detection confidence.
          *     > Note: When using this parameter, only events with the `vpn.confidence` property set to a valid value are returned. Events without a `vpn` Smart Signal result are left out of the response.
-         *      */
+         */
         vpn_confidence?: components['schemas']['SearchEventsVpnConfidence']
-        /** @description Filter events with Suspect Score result above a provided minimum threshold.
+        /**
+         * @description Filter events with Suspect Score result above a provided minimum threshold.
          *     > Note: When using this parameter, only events where the `suspect_score` property set to a value exceeding your threshold are returned. Events without a `suspect_score` Smart Signal result are left out of the response.
-         *      */
+         */
         min_suspect_score?: number
-        /** @description Filter events by Developer Tools detection result.
+        /**
+         * @description Filter events by Developer Tools detection result.
          *     > Note: When using this parameter, only events with the `developer_tools` property set to `true` or `false` are returned. Events without a `developer_tools` Smart Signal result are left out of the response.
-         *      */
+         */
         developer_tools?: boolean
-        /** @description Filter events by Location Spoofing detection result.
+        /**
+         * @description Filter events by Location Spoofing detection result.
          *     > Note: When using this parameter, only events with the `location_spoofing` property set to `true` or `false` are returned. Events without a `location_spoofing` Smart Signal result are left out of the response.
-         *      */
+         */
         location_spoofing?: boolean
-        /** @description Filter events by MITM (Man-in-the-Middle) Attack detection result.
+        /**
+         * @description Filter events by MITM (Man-in-the-Middle) Attack detection result.
          *     > Note: When using this parameter, only events with the `mitm_attack` property set to `true` or `false` are returned. Events without a `mitm_attack` Smart Signal result are left out of the response.
-         *      */
+         */
         mitm_attack?: boolean
-        /** @description Filter events by Device Rarity detection result.
+        /**
+         * @description Filter events by Device Rarity detection result.
          *     > Note: When using this parameter, only events with the `rare_device` property set to `true` or `false` are returned. Events without a Device Rarity Smart Signal result are left out of the response.
          *
          *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-         *      */
+         */
         rare_device?: boolean
-        /** @description Filter events by Device Rarity percentile bucket.
+        /**
+         * @description Filter events by Device Rarity percentile bucket.
          *     `<p95` - device configuration is in the bottom 95% (most common).
          *     `p95-p99` - device is in the 95th to 99th percentile.
          *     `p99-p99.5` - device is in the 99th to 99.5th percentile.
@@ -1683,51 +1992,55 @@ export interface operations {
          *     `not_seen` - device configuration has never been observed before.
          *
          *     > This Smart Signal is currently in beta and only available to select customers. If you are interested, please [contact our support team](https://fingerprint.com/support/).
-         *      */
+         */
         rare_device_percentile_bucket?: components['schemas']['SearchEventsRareDevicePercentileBucket']
-        /** @description Filter events by Proxy detection result.
+        /**
+         * @description Filter events by Proxy detection result.
          *     > Note: When using this parameter, only events with the `proxy` property set to `true` or `false` are returned. Events without a `proxy` Smart Signal result are left out of the response.
-         *      */
+         */
         proxy?: boolean
-        /** @description Filter events by a specific SDK version associated with the identification event (`sdk.version` property). Example: `3.11.14`
-         *      */
+        /** @description Filter events by a specific SDK version associated with the identification event (`sdk.version` property). Example: `3.11.14` */
         sdk_version?: string
-        /** @description Filter events by the SDK Platform associated with the identification event (`sdk.platform` property) .
+        /**
+         * @description Filter events by the SDK Platform associated with the identification event (`sdk.platform` property) .
          *     `js` - Javascript agent (Web).
          *     `ios` - Apple iOS based devices.
          *     `android` - Android based devices.
-         *      */
+         */
         sdk_platform?: components['schemas']['SearchEventsSdkPlatform']
-        /** @description Filter for events by providing one or more environment IDs (`environment_id` property).
+        /**
+         * @description Filter for events by providing one or more environment IDs (`environment_id` property).
          *
          *     ### Array syntax
          *     To provide multiple environment IDs, use the repeated keys syntax (`environment=env1&environment=env2`).
          *     Other notations like comma-separated (`environment=env1,env2`) or bracket notation (`environment[]=env1&environment[]=env2`) are not supported.
-         *      */
+         */
         environment?: string[]
-        /** @description Filter events by the most precise Proximity ID provided by default.
+        /**
+         * @description Filter events by the most precise Proximity ID provided by default.
          *     > Note: When using this parameter, only events with the `proximity.id` property matching the provided ID are returned. Events without a `proximity` result are left out of the response.
-         *      */
+         */
         proximity_id?: string
-        /** @description When set, the response will include a `total_hits` property with a count of total query matches across all pages, up to the specified limit.
-         *      */
+        /** @description When set, the response will include a `total_hits` property with a count of total query matches across all pages, up to the specified limit. */
         total_hits?: number
-        /** @description Filter events by Tor Node detection result.
+        /**
+         * @description Filter events by Tor Node detection result.
          *     > Note: When using this parameter, only events with the `tor_node` property set to `true` or `false` are returned. Events without a `tor_node` detection result are left out of the response.
-         *      */
+         */
         tor_node?: boolean
-        /** @description Filter events by their incremental identification status (`incremental_identification_status` property). Non incremental identification events are left out of the response.
-         *      */
+        /** @description Filter events by their incremental identification status (`incremental_identification_status` property). Non incremental identification events are left out of the response. */
         incremental_identification_status?: components['schemas']['SearchEventsIncrementalIdentificationStatus']
-        /** @description Filter events by iOS Simulator Detection result.
+        /**
+         * @description Filter events by iOS Simulator Detection result.
          *
          *     > Note: When using this parameter, only events with the `simulator` property set to `true` or `false` are returned. Events without a `simulator` Smart Signal result are left out of the response.
-         *      */
+         */
         simulator?: boolean
-        /** @description Selects the source of events to search. When omitted, only traditional identification events generated from devices are returned (the default behavior). When set to `edge`, only Automation Intelligence (Edge) events are returned.
+        /**
+         * @description Selects the source of events to search. When omitted, only traditional identification events generated from devices are returned (the default behavior). When set to `edge`, only Automation Intelligence (Edge) events are returned.
          *
          *     > Note: The Automation Intelligence API is in public preview testing phase.  If you encounter any issues, please [contact](https://fingerprint.com/support/) our support team.
-         *      */
+         */
         source?: components['schemas']['SearchEventsSource'][]
       }
       header?: never


### PR DESCRIPTION
- The generated types now include examples from the schema, after upgrading to the latest openapi-typescript version. Version 7.9 added support for the `examples` property (See https://github.com/openapi-ts/openapi-typescript/pull/2374)

The parameter examples are still missing.