### PR TITLE
INTER-1905: separate ServerApiError from RequestError

### DIFF
--- a/.changeset/request-error-non-json.md
+++ b/.changeset/request-error-non-json.md
@@ -1,0 +1,5 @@
+---
+'@fingerprint/node-sdk': patch
+---
+
+Throw a `RequestError` instead of a top-level `SdkError` when a Server API error response has a non-JSON body (e.g. an HTML error page from a proxy).

--- a/.changeset/separate-api-errors.md
+++ b/.changeset/separate-api-errors.md
@@ -9,4 +9,4 @@ Separate Server API errors from other request errors and strongly type the error
 - `TooManyRequestsError` now extends `ServerApiError`.
 - `RequestError` remains the base class for request-level errors and is thrown directly for non–Server-API responses (for example, errors returned by an intermediate proxy). Its `errorCode` stays a free-form `string` (a best-effort placeholder derived from `statusText`), exactly as before.
 
-This is a type-only change; runtime behavior is unchanged. `error instanceof RequestError` checks keep working, and `errorCode` stays populated on every error. To get the strictly typed `errorCode`, narrow to `ServerApiError` (`if (error instanceof ServerApiError) { error.errorCode }`).
+This is a backward-compatible change: structured Server API errors are now instances of `ServerApiError` (a subclass of `RequestError`). `error instanceof RequestError` checks keep working, and `errorCode` stays populated on every error. To get the strictly typed `errorCode`, narrow to `ServerApiError` (`if (error instanceof ServerApiError) { error.errorCode }`).

--- a/.changeset/separate-api-errors.md
+++ b/.changeset/separate-api-errors.md
@@ -1,0 +1,12 @@
+---
+'@fingerprint/node-sdk': minor
+---
+
+Separate Server API errors from other request errors and strongly type the error code.
+
+- Added `ServerApiError` (extends `RequestError`), thrown when the Server API returns a structured error response. It narrows `errorCode` to the strongly typed `ErrorCode` and exposes `responseBody: ErrorResponse`.
+- Exported the `ErrorCode` type (the union of error codes returned by the Fingerprint Server API).
+- `TooManyRequestsError` now extends `ServerApiError`.
+- `RequestError` remains the base class for request-level errors and is thrown directly for non–Server-API responses (for example, errors returned by an intermediate proxy). Its `errorCode` stays a free-form `string` (a best-effort placeholder derived from `statusText`), exactly as before.
+
+This is a type-only change; runtime behavior is unchanged. `error instanceof RequestError` checks keep working, and `errorCode` stays populated on every error. To get the strictly typed `errorCode`, narrow to `ServerApiError` (`if (error instanceof ServerApiError) { error.errorCode }`).

--- a/.changeset/strongly-typed-error-codes.md
+++ b/.changeset/strongly-typed-error-codes.md
@@ -1,7 +1,0 @@
----
-'@fingerprint/node-sdk': minor
----
-
-Strongly type the `RequestError.errorCode` field.
-
-`errorCode` is now typed as the `LooseAutocomplete<ErrorCode>` union (the set of error codes returned by the Fingerprint Server API) instead of a free-form `string`. The new `ErrorCode` type is also exported. This is a type-only change; runtime behavior is unchanged.

--- a/readme.md
+++ b/readme.md
@@ -113,38 +113,36 @@ See the [Examples](https://github.com/fingerprintjs/node-sdk/tree/main/example) 
 
 ### Error handling
 
-The Server API methods can throw `RequestError`.
-When handling errors, you can check for it like this:
+Most failures are a `ServerApiError`, thrown when the Server API responds with a structured error. It exposes a strongly typed `errorCode` (`ErrorCode`) alongside `statusCode`, `responseBody`, and the raw `response`:
 
 ```typescript
-import {
-  RequestError,
-  FingerprintServerApiClient,
-  Region,
-} from '@fingerprint/node-sdk'
+import { ServerApiError, FingerprintServerApiClient, Region } from '@fingerprint/node-sdk'
 
 const client = new FingerprintServerApiClient({
   apiKey: '<SECRET_API_KEY>',
   region: Region.Global,
 })
 
-// Handling getEvent errors
 try {
   const event = await client.getEvent(eventId)
   console.log(JSON.stringify(event, null, 2))
 } catch (error) {
-  if (error instanceof RequestError) {
-    console.log(error.responseBody) // Access parsed response body
-    console.log(error.response) // You can also access the raw response
-    // Fingerprint Server API error code like 'wrong_region'. For non–Server-API errors
-    // (e.g. proxy or load balancer), this is a best-effort placeholder outside the ErrorCode set.
-    console.log(error.errorCode)
-    console.log(`error ${error.statusCode}: `, error.message)
-  } else {
-    console.log('unknown error: ', error)
+  if (error instanceof ServerApiError) {
+    // `errorCode` is strongly typed as `ErrorCode`
+    if (error.errorCode === 'event_not_found') {
+      console.log('This event does not exist')
+    }
+    console.log(`error ${error.statusCode} (${error.errorCode}): `, error.message)
+    console.log(error.responseBody) // parsed response body
   }
 }
 ```
+
+Other errors, all subclasses of `SdkError`:
+
+- `TooManyRequestsError` — a `ServerApiError` thrown when the request is throttled (HTTP 429).
+- `RequestError` — the base class of `ServerApiError`, thrown when the response doesn't match the Server API error shape (e.g. a proxy error). Its `errorCode` is a free-form `string` placeholder from `statusText`. Since `ServerApiError` extends it, `error instanceof RequestError` catches both.
+- `SdkError` — the base of all SDK errors; also thrown for network failures and malformed responses.
 
 ### Webhooks
 

--- a/src/errors/apiErrors.ts
+++ b/src/errors/apiErrors.ts
@@ -1,6 +1,8 @@
 import { ErrorCode, ErrorResponse } from '../types'
-import { LooseAutocomplete } from '../typeUtils'
 
+/**
+ * Base class for all errors thrown by the SDK.
+ */
 export class SdkError extends Error {
   constructor(
     message: string,
@@ -12,14 +14,27 @@ export class SdkError extends Error {
   }
 }
 
+/**
+ * Error thrown when an HTTP request to the Fingerprint Server API fails.
+ *
+ * This is the base class for request-level errors. It is thrown directly when
+ * the server responds with an error that does not match the Server API error
+ * response shape (for example, an error returned by an intermediate proxy or
+ * load balancer).
+ *
+ * When the response is a structured Server API error, a {@link ServerApiError}
+ * (or one of its subclasses, such as {@link TooManyRequestsError}) is thrown
+ * instead. Those errors narrow {@link errorCode} to the strongly typed
+ * {@link ServerApiError.errorCode}.
+ */
 export class RequestError<Code extends number = number, Body = unknown> extends SdkError {
   // HTTP Status code
   readonly statusCode: Code
 
-  // Fingerprint Server API error code. Autocompletes to the known `ErrorCode` values, but stays
-  // widened to `string` because non–Server-API responses (see `RequestError.unknown`) carry a
-  // best-effort placeholder derived from `statusText` that may fall outside the `ErrorCode` union.
-  readonly errorCode: LooseAutocomplete<ErrorCode>
+  // Best-effort error code. On a plain `RequestError` (non–Server-API responses; see
+  // `RequestError.unknown`) this is a placeholder derived from `statusText`, so it is typed as a
+  // free-form `string`. `ServerApiError` narrows it to the strongly typed `ErrorCode`.
+  readonly errorCode: string
 
   // API error response
   readonly responseBody: Body
@@ -27,13 +42,7 @@ export class RequestError<Code extends number = number, Body = unknown> extends 
   // Raw HTTP response
   override readonly response: Response
 
-  constructor(
-    message: string,
-    body: Body,
-    statusCode: Code,
-    errorCode: LooseAutocomplete<ErrorCode>,
-    response: Response
-  ) {
+  constructor(message: string, body: Body, statusCode: Code, errorCode: string, response: Response) {
     super(message, response)
     this.responseBody = body
     this.response = response
@@ -41,22 +50,37 @@ export class RequestError<Code extends number = number, Body = unknown> extends 
     this.statusCode = statusCode
   }
 
-  static unknown(response: Response) {
+  static unknown(response: Response, body?: unknown) {
     // Non–Server-API responses (e.g. proxy or load balancer errors) carry no structured error
-    // code, so `statusText` is used as a best-effort placeholder for now.
-    return new RequestError('Unknown error', undefined, response.status, response.statusText, response)
+    // code, so `statusText` is used as a best-effort placeholder.
+    return new RequestError('Unknown error', body, response.status, response.statusText, response)
+  }
+}
+
+/**
+ * Error thrown when the Fingerprint Server API returns a structured error
+ * response. In addition to the {@link RequestError} properties, it exposes a
+ * strongly typed {@link errorCode} describing the reason for the failure.
+ */
+export class ServerApiError<Code extends number = number> extends RequestError<Code, ErrorResponse> {
+  // Narrow the inherited `errorCode` to the strongly typed Server API union. The value is set by
+  // the `RequestError` constructor; `declare` only refines its type (no runtime field is emitted).
+  declare readonly errorCode: ErrorCode
+
+  constructor(body: ErrorResponse, statusCode: Code, response: Response) {
+    super(body.error.message, body, statusCode, body.error.code, response)
   }
 
   static fromErrorResponse(body: ErrorResponse, response: Response) {
-    return new RequestError(body.error.message, body, response.status, body.error.code, response)
+    return new ServerApiError(body, response.status, response)
   }
 }
 
 /**
  * Error that indicates that the request was throttled.
  */
-export class TooManyRequestsError extends RequestError<429, ErrorResponse> {
+export class TooManyRequestsError extends ServerApiError<429> {
   constructor(body: ErrorResponse, response: Response) {
-    super(body.error.message, body, 429, body.error.code, response)
+    super(body, 429, response)
   }
 }

--- a/src/errors/handleErrorResponse.ts
+++ b/src/errors/handleErrorResponse.ts
@@ -8,6 +8,8 @@ export function isErrorResponse(value: unknown): value is ErrorResponse {
     typeof value.error === 'object' &&
     value.error !== null &&
     'code' in value.error &&
-    'message' in value.error
+    typeof value.error.code === 'string' &&
+    'message' in value.error &&
+    typeof value.error.message === 'string'
   )
 }

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -322,7 +322,7 @@ export class FingerprintServerApiClient implements FingerprintApi {
       return this.parseJson(response)
     }
 
-    const errorPayload = await this.parseJson<unknown>(response.clone())
+    const errorPayload = await this.parseErrorBody(response)
 
     if (response.status === 429 && isErrorResponse(errorPayload)) {
       throw new TooManyRequestsError(errorPayload, response)
@@ -341,6 +341,32 @@ export class FingerprintServerApiClient implements FingerprintApi {
       return (await response.json()) as T
     } catch (e) {
       throw new SdkError('Failed to parse JSON response', response, toError(e))
+    }
+  }
+
+  /**
+   * Parse the body of an error (non-ok) response defensively. Unlike {@link parseJson}, this never
+   * throws: proxies and load balancers can return non-JSON error bodies (e.g. an HTML error page),
+   * and we still want to surface a {@link RequestError} rather than a top-level {@link SdkError}.
+   * A non-JSON body is returned as raw text so it is preserved on `RequestError.responseBody`.
+   */
+  private async parseErrorBody(response: Response): Promise<unknown> {
+    let text: string
+    try {
+      text = await response.clone().text()
+    } catch {
+      return undefined
+    }
+
+    if (text === '') {
+      return undefined
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return JSON.parse(text) as unknown
+    } catch {
+      return text
     }
   }
 }

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -363,8 +363,7 @@ export class FingerprintServerApiClient implements FingerprintApi {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      return JSON.parse(text) as unknown
+      return JSON.parse(text)
     } catch {
       return text
     }

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -9,7 +9,7 @@ import {
   SearchEventsFilter,
   SearchEventsResponse,
 } from './types'
-import { RequestError, SdkError, TooManyRequestsError } from './errors/apiErrors'
+import { ServerApiError, RequestError, SdkError, TooManyRequestsError } from './errors/apiErrors'
 import { isErrorResponse } from './errors/handleErrorResponse'
 import { toError } from './errors/toError'
 
@@ -328,16 +328,10 @@ export class FingerprintServerApiClient implements FingerprintApi {
       throw new TooManyRequestsError(errorPayload, response)
     }
     if (isErrorResponse(errorPayload)) {
-      throw new RequestError(
-        errorPayload.error.message,
-        errorPayload,
-        response.status,
-        errorPayload.error.code,
-        response
-      )
+      throw new ServerApiError(errorPayload, response.status, response)
     }
 
-    throw RequestError.unknown(response)
+    throw RequestError.unknown(response, errorPayload)
   }
 
   private async parseJson<T>(response: Response): Promise<T> {

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -1,6 +1,0 @@
-/**
- * Union that keeps autocomplete for the known values of `T` while still accepting any string.
- * Useful for fields whose value is usually one of a known set but can legitimately be something
- * else at runtime.
- */
-export type LooseAutocomplete<T extends string> = T | (string & {})

--- a/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
+++ b/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
@@ -1,5 +1,5 @@
 import {
-  ErrorResponse,
+  ServerApiError,
   FingerprintServerApiClient,
   Region,
   RequestError,
@@ -42,9 +42,12 @@ describe('[Mocked response] Delete visitor data', () => {
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error404 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error404.error.message,
+      errorCode: Error404.error.code,
+    })
   })
 
   it('403 error', async () => {
@@ -54,9 +57,12 @@ describe('[Mocked response] Delete visitor data', () => {
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error403 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error403.error.message,
+      errorCode: Error403.error.code,
+    })
   })
 
   it('400 error', async () => {
@@ -66,9 +72,12 @@ describe('[Mocked response] Delete visitor data', () => {
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error400 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error400.error.message,
+      errorCode: Error400.error.code,
+    })
   })
 
   it('429 error', async () => {
@@ -78,8 +87,12 @@ describe('[Mocked response] Delete visitor data', () => {
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    const expectedError = new TooManyRequestsError(Error429 as ErrorResponse, mockResponse)
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow(expectedError)
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(TooManyRequestsError)
+    expect(caught).toMatchObject({
+      message: Error429.error.message,
+      errorCode: Error429.error.code,
+    })
   })
 
   it('Error with bad JSON', async () => {
@@ -111,7 +124,9 @@ describe('[Mocked response] Delete visitor data', () => {
 
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow(RequestError as any)
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toThrow('Unknown error')
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: 'Unknown error' })
   })
 })

--- a/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
+++ b/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
@@ -1,11 +1,4 @@
-import {
-  ServerApiError,
-  FingerprintServerApiClient,
-  Region,
-  RequestError,
-  SdkError,
-  TooManyRequestsError,
-} from '../../src'
+import { ServerApiError, FingerprintServerApiClient, Region, RequestError, TooManyRequestsError } from '../../src'
 import Error404 from './mocked-responses-data/errors/404_visitor_not_found.json'
 import Error403 from './mocked-responses-data/errors/403_feature_not_enabled.json'
 import Error400 from './mocked-responses-data/errors/400_visitor_id_invalid.json'
@@ -95,18 +88,19 @@ describe('[Mocked response] Delete visitor data', () => {
     })
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/mocked-responses-tests/getEventTests.spec.ts
+++ b/tests/mocked-responses-tests/getEventTests.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ServerApiError,
   ErrorResponse,
   FingerprintServerApiClient,
   Region,
@@ -60,9 +61,9 @@ describe('[Mocked response] Get Event', () => {
     } satisfies ErrorResponse
     const mockResponse = createJsonResponse(errorInfo, 403)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(client.getEvent(existingEventId)).rejects.toThrow(
-      RequestError.fromErrorResponse(errorInfo, mockResponse)
-    )
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: errorInfo.error.message, errorCode: errorInfo.error.code })
   })
 
   it('404 error', async () => {
@@ -74,9 +75,9 @@ describe('[Mocked response] Get Event', () => {
     } satisfies ErrorResponse
     const mockResponse = createJsonResponse(errorInfo, 404)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(client.getEvent(existingEventId)).rejects.toThrow(
-      RequestError.fromErrorResponse(errorInfo, mockResponse)
-    )
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: errorInfo.error.message, errorCode: errorInfo.error.code })
   })
 
   it('Error with unknown', async () => {
@@ -87,21 +88,30 @@ describe('[Mocked response] Get Event', () => {
       404
     )
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(client.getEvent(existingEventId)).rejects.toThrow(RequestError)
-    await expect(client.getEvent(existingEventId)).rejects.toThrow('Unknown error')
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: 'Unknown error' })
   })
 
   it('429 error with valid shape', async () => {
     const mockResponse = createJsonResponse(Error429, 429)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(client.getEvent(existingEventId)).rejects.toBeInstanceOf(TooManyRequestsError)
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(TooManyRequestsError)
+    expect(caught).toMatchObject({
+      message: Error429.error.message,
+      errorCode: Error429.error.code,
+    })
   })
 
   it('429 error with invalid shape', async () => {
     const mockResponse = createJsonResponse({ reason: 'rate limited' }, 429)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(client.getEvent(existingEventId)).rejects.toBeInstanceOf(RequestError)
-    await expect(client.getEvent(existingEventId)).rejects.not.toBeInstanceOf(TooManyRequestsError)
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).not.toBeInstanceOf(TooManyRequestsError)
   })
 
   it('Error with bad JSON', async () => {

--- a/tests/mocked-responses-tests/getEventTests.spec.ts
+++ b/tests/mocked-responses-tests/getEventTests.spec.ts
@@ -4,7 +4,6 @@ import {
   FingerprintServerApiClient,
   Region,
   RequestError,
-  SdkError,
   TooManyRequestsError,
 } from '../../src'
 import getEventResponse from './mocked-responses-data/events/get_event_200.json'
@@ -114,18 +113,19 @@ describe('[Mocked response] Get Event', () => {
     expect(caught).not.toBeInstanceOf(TooManyRequestsError)
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.getEvent(existingEventId)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/mocked-responses-tests/searchEventsTests.spec.ts
+++ b/tests/mocked-responses-tests/searchEventsTests.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse, FingerprintServerApiClient, RequestError, SearchEventsFilter } from '../../src'
+import { ServerApiError, ErrorResponse, FingerprintServerApiClient, SearchEventsFilter } from '../../src'
 import getEventsSearch from './mocked-responses-data/events/search/get_event_search_200.json'
 import { createJsonResponse } from './utils'
 import { getIntegrationInfo } from '../../src/urlUtils'
@@ -167,11 +167,13 @@ describe('[Mocked response] Search Events', () => {
     } satisfies ErrorResponse
     const mockResponse = createJsonResponse(error, 400)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(
-      client.searchEvents({
+    const caught = await client
+      .searchEvents({
         limit: 10,
       })
-    ).rejects.toThrow(RequestError.fromErrorResponse(error, mockResponse))
+      .catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: error.error.message, errorCode: error.error.code })
   })
 
   it('403 error', async () => {
@@ -183,10 +185,12 @@ describe('[Mocked response] Search Events', () => {
     } satisfies ErrorResponse
     const mockResponse = createJsonResponse(error, 403)
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
-    await expect(
-      client.searchEvents({
+    const caught = await client
+      .searchEvents({
         limit: 10,
       })
-    ).rejects.toThrow(RequestError.fromErrorResponse(error, mockResponse))
+      .catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: error.error.message, errorCode: error.error.code })
   })
 })

--- a/tests/mocked-responses-tests/updateEventTests.spec.ts
+++ b/tests/mocked-responses-tests/updateEventTests.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse, FingerprintServerApiClient, Region, RequestError, SdkError } from '../../src'
+import { ServerApiError, FingerprintServerApiClient, Region, RequestError, SdkError } from '../../src'
 import Error404 from './mocked-responses-data/errors/404_event_not_found.json'
 import Error403 from './mocked-responses-data/errors/403_feature_not_enabled.json'
 import Error400 from './mocked-responses-data/errors/400_request_body_invalid.json'
@@ -48,9 +48,12 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error404 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error404.error.message,
+      errorCode: Error404.error.code,
+    })
   })
 
   it('403 error', async () => {
@@ -64,9 +67,12 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error403 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error403.error.message,
+      errorCode: Error403.error.code,
+    })
   })
 
   it('400 error', async () => {
@@ -80,9 +86,12 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error400 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error400.error.message,
+      errorCode: Error400.error.code,
+    })
   })
 
   it('409 error', async () => {
@@ -96,9 +105,12 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow(
-      RequestError.fromErrorResponse(Error409 as ErrorResponse, mockResponse)
-    )
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      message: Error409.error.message,
+      errorCode: Error409.error.code,
+    })
   })
 
   it('Error with bad JSON', async () => {
@@ -137,7 +149,9 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow(RequestError)
-    await expect(client.updateEvent(existingEventId, body)).rejects.toThrow('Unknown error')
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: 'Unknown error' })
   })
 })

--- a/tests/mocked-responses-tests/updateEventTests.spec.ts
+++ b/tests/mocked-responses-tests/updateEventTests.spec.ts
@@ -1,4 +1,4 @@
-import { ServerApiError, FingerprintServerApiClient, Region, RequestError, SdkError } from '../../src'
+import { ServerApiError, FingerprintServerApiClient, Region, RequestError } from '../../src'
 import Error404 from './mocked-responses-data/errors/404_event_not_found.json'
 import Error403 from './mocked-responses-data/errors/403_feature_not_enabled.json'
 import Error400 from './mocked-responses-data/errors/400_request_body_invalid.json'
@@ -113,7 +113,7 @@ describe('[Mocked response] Update event', () => {
     })
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
@@ -123,12 +123,13 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -339,28 +339,32 @@ describe('ServerApiClient', () => {
     await expect(client.getEvent('<event>')).rejects.toMatchObject({ cause: expect.any(SyntaxError) })
   })
 
-  it('throws SdkError when error response has invalid json', async () => {
-    const badJsonFail = {
-      ok: false,
-      status: 500,
-      headers: new Headers({ 'content-type': 'text/plain' }),
-      json: vi.fn().mockRejectedValue('Unexpected error format'),
-      clone: vi.fn(),
-    }
-
-    badJsonFail.clone.mockReturnValue(badJsonFail)
-
-    const mockFetch = vi.fn().mockResolvedValue(badJsonFail as unknown as Response)
+  it('throws a plain RequestError instead of a generic SdkError when the error response body is not JSON', async () => {
+    // Proxies/load balancers can return non-JSON error bodies (e.g. an HTML error page).
+    const htmlErrorBody = '<html><body><h1>502 Bad Gateway</h1></body></html>'
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(htmlErrorBody, {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'content-type': 'text/html' },
+      })
+    )
 
     const client = new FingerprintServerApiClient({
       fetch: mockFetch,
       apiKey: 'test',
     })
 
-    await expect(client.getEvent('<event>')).rejects.toThrow('Failed to parse JSON response')
+    const caught = await client.getEvent('<event>').catch((e: unknown) => e)
 
-    await expect(client.getEvent('<event>')).rejects.toBeInstanceOf(SdkError)
-
-    await expect(client.getEvent('<event>')).rejects.toMatchObject({ cause: Error('Unexpected error format') })
+    // RequestError extends SdkError, so we assert the specific subtype rather than `not SdkError`.
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 502,
+      errorCode: 'Bad Gateway',
+      message: 'Unknown error',
+      responseBody: htmlErrorBody, // raw non-JSON body preserved
+    })
   })
 })

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -1,4 +1,13 @@
-import { RequestError, FingerprintServerApiClient, Region, Options, EventUpdate, SdkError } from '../../src'
+import {
+  ServerApiError,
+  RequestError,
+  FingerprintServerApiClient,
+  Region,
+  Options,
+  EventUpdate,
+  SdkError,
+  ErrorResponse,
+} from '../../src'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('ServerApiClient', () => {
@@ -58,6 +67,98 @@ describe('ServerApiClient', () => {
     }
 
     throw new Error('Expected EventError to be thrown')
+  })
+
+  it('throws a strongly typed ServerApiError for structured Server API error responses', async () => {
+    const responseBody = {
+      error: {
+        code: 'feature_not_enabled',
+        message: 'feature not enabled',
+      },
+    }
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(responseBody), { status: 403, headers: { 'content-type': 'application/json' } })
+      )
+
+    const client = new FingerprintServerApiClient({
+      fetch: mockFetch,
+      apiKey: 'test',
+      region: Region.Global,
+    })
+
+    try {
+      await client.getEvent('test')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ServerApiError)
+      // ServerApiError is still a RequestError, so existing `instanceof` checks keep working.
+      expect(e).toBeInstanceOf(RequestError)
+      if (e instanceof ServerApiError) {
+        expect(e.errorCode).toBe('feature_not_enabled')
+        expect(e.statusCode).toBe(403)
+        expect(e.responseBody).toEqual(responseBody)
+        expect(e.message).toBe('feature not enabled')
+        return
+      }
+    }
+
+    throw new Error('Expected ServerApiError to be thrown')
+  })
+
+  it('ServerApiError.fromErrorResponse builds a ServerApiError from a structured error body', () => {
+    const body = {
+      error: { code: 'feature_not_enabled', message: 'feature not enabled' },
+    } satisfies ErrorResponse
+    const response = new Response(JSON.stringify(body), { status: 403 })
+
+    const error = ServerApiError.fromErrorResponse(body, response)
+
+    expect(error).toBeInstanceOf(ServerApiError)
+    expect(error).toBeInstanceOf(RequestError)
+    expect(error.errorCode).toBe('feature_not_enabled')
+    expect(error.statusCode).toBe(403)
+    expect(error.responseBody).toEqual(body)
+    expect(error.message).toBe('feature not enabled')
+    expect(error.response).toBe(response)
+  })
+
+  it('throws a plain RequestError with a placeholder error code for non Server API error responses', async () => {
+    const unexpectedBody = { unexpected: 'shape' }
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(unexpectedBody), {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const client = new FingerprintServerApiClient({
+      fetch: mockFetch,
+      apiKey: 'test',
+      region: Region.Global,
+    })
+
+    try {
+      await client.getEvent('test')
+    } catch (e) {
+      expect(e).toBeInstanceOf(RequestError)
+      expect(e).not.toBeInstanceOf(ServerApiError)
+      if (e instanceof RequestError) {
+        // Backwards compatible: `errorCode` stays populated on the base RequestError, carrying the
+        // best-effort `statusText` placeholder for non–Server-API (e.g. proxy) responses.
+        expect(e.errorCode).toBe('Bad Gateway')
+        expect(e.errorCode).toBe(e.response.statusText)
+        expect(e.statusCode).toBe(502)
+        expect(e.message).toBe('Unknown error')
+        // The parsed payload is preserved for debugging unexpected/proxy errors.
+        expect(e.responseBody).toEqual(unexpectedBody)
+        return
+      }
+    }
+
+    throw new Error('Expected RequestError to be thrown')
   })
 
   it('should support using a string constant for the Region', () => {

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -161,6 +161,31 @@ describe('ServerApiClient', () => {
     throw new Error('Expected RequestError to be thrown')
   })
 
+  it('does not classify a payload with a non-string error code/message as a ServerApiError', async () => {
+    // An `error` object is present but its `code`/`message` are not strings (e.g. a proxy that
+    // happens to nest an object under `error`). It must not be treated as a structured Server API
+    // error, otherwise `errorCode`/`message` would be non-string at runtime.
+    const proxyBody = { error: { code: 123, message: { nested: 'oops' } } }
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(proxyBody), {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const client = new FingerprintServerApiClient({
+      fetch: mockFetch,
+      apiKey: 'test',
+      region: Region.Global,
+    })
+
+    const caught = await client.getEvent('test').catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({ message: 'Unknown error', errorCode: 'Bad Gateway', responseBody: proxyBody })
+  })
+
   it('should support using a string constant for the Region', () => {
     const client = new FingerprintServerApiClient({
       apiKey: 'test',


### PR DESCRIPTION
- Add `ServerApiError extends RequestError` for structured Server API errors; it narrows `errorCode` to the typed `ErrorCode` and exposes `responseBody: ErrorResponse`.
- `TooManyRequestsError` now extends `ServerApiError`.
- `RequestError` stays the base for request-level errors (thrown for non–Server-API/proxy responses); its `errorCode` remains a free-form `string` placeholder, as before.
- Export `ErrorCode`; remove the base's now-unused `LooseAutocomplete`/`typeUtils.ts`.

Type-only change, no runtime impact: `errorCode` stays populated on every error and `instanceof RequestError` keeps working. Narrow to `ServerApiError` for the typed `errorCode`.

### Ship together with #251

This PR removes `LooseAutocomplete`/`typeUtils.ts` that its base (#251) adds, so the two must land in the **same release** — otherwise #251 ships `LooseAutocomplete` and this PR removes it.