### PR TITLE
INTER-1375: throw RequestError for non-JSON Server API error responses

### DIFF
--- a/.changeset/request-error-non-json.md
+++ b/.changeset/request-error-non-json.md
@@ -1,0 +1,5 @@
+---
+'@fingerprint/node-sdk': patch
+---
+
+Throw a `RequestError` instead of a top-level `SdkError` when a Server API error response has a non-JSON body (e.g. an HTML error page from a proxy).

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -322,7 +322,7 @@ export class FingerprintServerApiClient implements FingerprintApi {
       return this.parseJson(response)
     }
 
-    const errorPayload = await this.parseJson<unknown>(response.clone())
+    const errorPayload = await this.parseErrorBody(response)
 
     if (response.status === 429 && isErrorResponse(errorPayload)) {
       throw new TooManyRequestsError(errorPayload, response)
@@ -341,6 +341,32 @@ export class FingerprintServerApiClient implements FingerprintApi {
       return (await response.json()) as T
     } catch (e) {
       throw new SdkError('Failed to parse JSON response', response, toError(e))
+    }
+  }
+
+  /**
+   * Parse the body of an error (non-ok) response defensively. Unlike {@link parseJson}, this never
+   * throws: proxies and load balancers can return non-JSON error bodies (e.g. an HTML error page),
+   * and we still want to surface a {@link RequestError} rather than a top-level {@link SdkError}.
+   * A non-JSON body is returned as raw text so it is preserved on `RequestError.responseBody`.
+   */
+  private async parseErrorBody(response: Response): Promise<unknown> {
+    let text: string
+    try {
+      text = await response.clone().text()
+    } catch {
+      return undefined
+    }
+
+    if (text === '') {
+      return undefined
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      return JSON.parse(text) as unknown
+    } catch {
+      return text
     }
   }
 }

--- a/src/serverApiClient.ts
+++ b/src/serverApiClient.ts
@@ -363,8 +363,7 @@ export class FingerprintServerApiClient implements FingerprintApi {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      return JSON.parse(text) as unknown
+      return JSON.parse(text)
     } catch {
       return text
     }

--- a/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
+++ b/tests/mocked-responses-tests/deleteVisitorDataTests.spec.ts
@@ -1,11 +1,4 @@
-import {
-  ServerApiError,
-  FingerprintServerApiClient,
-  Region,
-  RequestError,
-  SdkError,
-  TooManyRequestsError,
-} from '../../src'
+import { ServerApiError, FingerprintServerApiClient, Region, RequestError, TooManyRequestsError } from '../../src'
 import Error404 from './mocked-responses-data/errors/404_visitor_not_found.json'
 import Error403 from './mocked-responses-data/errors/403_feature_not_enabled.json'
 import Error400 from './mocked-responses-data/errors/400_visitor_id_invalid.json'
@@ -95,18 +88,19 @@ describe('[Mocked response] Delete visitor data', () => {
     })
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.deleteVisitorData(existingVisitorId)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.deleteVisitorData(existingVisitorId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/mocked-responses-tests/getEventTests.spec.ts
+++ b/tests/mocked-responses-tests/getEventTests.spec.ts
@@ -4,7 +4,6 @@ import {
   FingerprintServerApiClient,
   Region,
   RequestError,
-  SdkError,
   TooManyRequestsError,
 } from '../../src'
 import getEventResponse from './mocked-responses-data/events/get_event_200.json'
@@ -114,18 +113,19 @@ describe('[Mocked response] Get Event', () => {
     expect(caught).not.toBeInstanceOf(TooManyRequestsError)
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
     mockFetch.mockReturnValue(Promise.resolve(mockResponse))
 
-    await expect(client.getEvent(existingEventId)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.getEvent(existingEventId).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/mocked-responses-tests/updateEventTests.spec.ts
+++ b/tests/mocked-responses-tests/updateEventTests.spec.ts
@@ -1,4 +1,4 @@
-import { ServerApiError, FingerprintServerApiClient, Region, RequestError, SdkError } from '../../src'
+import { ServerApiError, FingerprintServerApiClient, Region, RequestError } from '../../src'
 import Error404 from './mocked-responses-data/errors/404_event_not_found.json'
 import Error403 from './mocked-responses-data/errors/403_feature_not_enabled.json'
 import Error400 from './mocked-responses-data/errors/400_request_body_invalid.json'
@@ -113,7 +113,7 @@ describe('[Mocked response] Update event', () => {
     })
   })
 
-  it('Error with bad JSON', async () => {
+  it('Error with bad JSON throws a RequestError with the raw body preserved', async () => {
     const mockResponse = new Response('(Some bad JSON)', {
       status: 404,
     })
@@ -123,12 +123,13 @@ describe('[Mocked response] Update event', () => {
       linked_id: 'linked_id',
       suspect: true,
     }
-    await expect(client.updateEvent(existingEventId, body)).rejects.toMatchObject({
-      name: SdkError.name,
-      message: 'Failed to parse JSON response',
-      response: mockResponse,
-      // The exact message is engine-specific, assert only the error type
-      cause: expect.any(SyntaxError),
+    const caught = await client.updateEvent(existingEventId, body).catch((e: unknown) => e)
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 404,
+      message: 'Unknown error',
+      responseBody: '(Some bad JSON)',
     })
   })
 

--- a/tests/unit-tests/serverApiClientTests.spec.ts
+++ b/tests/unit-tests/serverApiClientTests.spec.ts
@@ -339,28 +339,32 @@ describe('ServerApiClient', () => {
     await expect(client.getEvent('<event>')).rejects.toMatchObject({ cause: expect.any(SyntaxError) })
   })
 
-  it('throws SdkError when error response has invalid json', async () => {
-    const badJsonFail = {
-      ok: false,
-      status: 500,
-      headers: new Headers({ 'content-type': 'text/plain' }),
-      json: vi.fn().mockRejectedValue('Unexpected error format'),
-      clone: vi.fn(),
-    }
-
-    badJsonFail.clone.mockReturnValue(badJsonFail)
-
-    const mockFetch = vi.fn().mockResolvedValue(badJsonFail as unknown as Response)
+  it('throws a plain RequestError instead of a generic SdkError when the error response body is not JSON', async () => {
+    // Proxies/load balancers can return non-JSON error bodies (e.g. an HTML error page).
+    const htmlErrorBody = '<html><body><h1>502 Bad Gateway</h1></body></html>'
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(htmlErrorBody, {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'content-type': 'text/html' },
+      })
+    )
 
     const client = new FingerprintServerApiClient({
       fetch: mockFetch,
       apiKey: 'test',
     })
 
-    await expect(client.getEvent('<event>')).rejects.toThrow('Failed to parse JSON response')
+    const caught = await client.getEvent('<event>').catch((e: unknown) => e)
 
-    await expect(client.getEvent('<event>')).rejects.toBeInstanceOf(SdkError)
-
-    await expect(client.getEvent('<event>')).rejects.toMatchObject({ cause: Error('Unexpected error format') })
+    // RequestError extends SdkError, so we assert the specific subtype rather than `not SdkError`.
+    expect(caught).toBeInstanceOf(RequestError)
+    expect(caught).not.toBeInstanceOf(ServerApiError)
+    expect(caught).toMatchObject({
+      statusCode: 502,
+      errorCode: 'Bad Gateway',
+      message: 'Unknown error',
+      responseBody: htmlErrorBody, // raw non-JSON body preserved
+    })
   })
 })


### PR DESCRIPTION
- When a non-ok response has a non-JSON body (e.g. an HTML error page from a proxy or load balancer), the SDK now throws a `RequestError` instead of a top-level `SdkError`.
- Adds `parseErrorBody`, which parses the error body defensively and never throws; a non-JSON body is preserved as raw text on `RequestError.responseBody`.
- Successful (2xx) responses with an invalid JSON body still throw `SdkError`, as before.

[INTER-1375](https://fingerprintjs.atlassian.net/browse/INTER-1375) — fixes [#204](https://github.com/fingerprintjs/node-sdk/issues/204).

### Stacked on #260

Targets `refactor/separate-api-errors`; review/merge [#260](https://github.com/fingerprintjs/node-sdk/pull/260) first. It relies on the `ServerApiError` split introduced there.

[INTER-1375]: https://fingerprintjs.atlassian.net/browse/INTER-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ