### PR TITLE
fix(eslint): ignore _dx-toolkit checkout during schema sync

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,8 @@ import dxTeamConfig from '@fingerprintjs/eslint-config-dx-team/type-checked'
 
 export default [
   {
+    // `_dx-toolkit/**`: the schema-sync action checks the toolkit out here inside the
+    // working tree; ESLint doesn't honor git excludes, so ignore it explicitly.
     ignores: ['dist/**', 'docs/**', 'coverage/**', 'resources/**', '_dx-toolkit/**'],
   },
   ...dxTeamConfig,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import dxTeamConfig from '@fingerprintjs/eslint-config-dx-team/type-checked'
 
 export default [
   {
-    ignores: ['dist/**', 'docs/**', 'coverage/**', 'resources/**'],
+    ignores: ['dist/**', 'docs/**', 'coverage/**', 'resources/**', '_dx-toolkit/**'],
   },
   ...dxTeamConfig,
   {


### PR DESCRIPTION
## Problem

The schema-sync job fails at `pnpm generateTypes` ([run](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/30560528447/job/90945566751)).

The sync action puts the toolkit in `_dx-toolkit/` inside the SDK tree and hides it via git's `.git/info/exclude`. ESLint does not read git ignores, so `eslint --max-warnings 0 .` lints the toolkit's own `.ts` files. They are not in any tsconfig, so the parser errors and the job fails.

Only happens when `_dx-toolkit/` exists, so it does not reproduce in a normal local checkout.

## Fix

Add `_dx-toolkit/**` to the ESLint `ignores` — the ESLint version of the action's git-exclude line.

## Verified

Recreated `_dx-toolkit/.../main.ts` → same error. With the fix, lint passes; normal tree unchanged.

## Note

Node-side patch. A cross-SDK fix belongs in `dx-team-toolkit` (use remote action refs, or check the SDK out into a subdir).