### PR TITLE
[api-v3] Add missing changeset for Server API schema v3.5.2

### DIFF
--- a/.changeset/silly-schema-update.md
+++ b/.changeset/silly-schema-update.md
@@ -1,0 +1,11 @@
+---
+"@fingerprintjs/fingerprintjs-pro-server-api": minor
+---
+
+Update Server API schema to v3.5.2:
+
+- Add `rareDevice` Smart Signal with `result` and `percentileBucket` fields, plus `rare_device` and `rare_device_percentile_bucket` query filters on the events search endpoint
+- Add `labels` field with machine learning based predictions for specific use cases (beta)
+- Add `mlScore` fields to the `VPN` and `Proxy` signals, and `mlPrediction` to `IPInfoASN`'s VPN info (beta)
+- Add `unknown` to the `proxyType` enum for proxies detected solely by the ML model
+- Clarify the `DeveloperTools` signal description to cover Android/iOS devices


### PR DESCRIPTION
## Why

#269 updated the `api-v3` branch's Server API schema to `v3.5.2` (new `rareDevice` signal, `labels` field, `mlScore`/`mlPrediction` additions, new `proxyType: unknown` enum value) but didn't include a changeset. Without one, the Release workflow has nothing to version, so the schema update can't be published to npm.

## What

Adds a `minor` changeset for `@fingerprintjs/fingerprintjs-pro-server-api` describing the schema v3.5.2 changes, so merging this will let the Release workflow open a "Version Packages" PR that bumps the package version and, once merged, publishes the new release.