### PR TITLE
[api-v3] Stop api-v3 releases from being marked "Latest" on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       language-version: 24
       prepare-command: pnpm build
       useTrustedPublishing: true
-      skipMarkingReleaseLatest: ${{ github.ref_name == 'api-v3' }}
+      unmarkReleaseAsLatest: ${{ github.ref_name == 'api-v3' }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       language-version: 24
       prepare-command: pnpm build
       useTrustedPublishing: true
+      skipMarkingReleaseLatest: ${{ github.ref_name == 'api-v3' }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Why

GitHub Releases are repo-wide, not per-branch. A release cut from `api-v3` (legacy `@fingerprintjs/fingerprintjs-pro-server-api`, Server API v3) recently became the repo's "Latest" release on GitHub, ahead of the actual current `@fingerprint/node-sdk` (Server API v4) release from `main`.

## What

Passes the new `unmarkReleaseAsLatest ` input to the shared release workflow, set to `true` only when triggered from `api-v3`:
```yaml
unmarkReleaseAsLatest: ${{ github.ref_name == 'api-v3' }}
```

## Depends on ✅ 

**Draft — blocked on [fingerprintjs/dx-team-toolkit#194](https://github.com/fingerprintjs/dx-team-toolkit/pull/194)**, which adds the `unmarkReleaseAsLatest ` input this relies on. Will mark ready for review once that's merged.